### PR TITLE
Update __init__.py

### DIFF
--- a/wlauto/devices/android/tc2/__init__.py
+++ b/wlauto/devices/android/tc2/__init__.py
@@ -834,6 +834,9 @@ class TC2Device(BigLittleDevice):
         target.expect(self.config.bootmon_prompt)
         target.sendline('fl linux initrd ' + self.config.initrd)
         target.expect(self.config.bootmon_prompt)
+        #Workaround TC2 bootmon serial issue for loading large initrd blob
+        target.sendline(' ')
+        target.expect(self.config.bootmon_prompt)
         target.sendline('fl linux boot ' + self.config.kernel + self.config.kernel_arguments)
 
 


### PR DESCRIPTION
The boot monitor seems to have some buffer overrun issue while loading the latest Linaro android images.
The behavior is after loading the initrd, the kernel loading will fail, very likely to due command line buffer overrun.
the new initrd in the Linaro image is 3 times larger than the previous version, which could cause the issue.
putting a dummy enter between loading initrd and the kernel could resolve the issue.