### PR TITLE
Fix Param documentation

### DIFF
--- a/wlauto/core/extension.py
+++ b/wlauto/core/extension.py
@@ -139,9 +139,7 @@ class Param(object):
         :param kind: The type of parameter this is. This must be a callable that takes an arbitrary
                      object and converts it to the expected type, or raised ``ValueError`` if such
                      conversion is not possible. Most Python standard types -- ``str``, ``int``, ``bool``, etc. --
-                     can be used here (though for ``bool``, ``wlauto.utils.misc.as_bool`` is preferred
-                     as it intuitively handles strings like ``'false'``). This defaults to ``str`` if
-                     not specified.
+                     can be used here. This defaults to ``str`` if not specified.
         :param mandatory: If set to ``True``, then a non-``None`` value for this parameter *must* be
                           provided on extension object construction, otherwise ``ConfigError`` will be
                           raised.


### PR DESCRIPTION
The param documentation states that for a boolean, "kind" should be
"as_bool" from wlauto.utils.misc, but there is no "as_bool".  Currently,
workload automation automatically converts native python types like bool
and int to workload automation specific ones.  Remove this bit from the
documentation as it's not true any more.