### PR TITLE
Fix trace-cmd after 2276ae0c5b54

### DIFF
--- a/wlauto/core/configuration.py
+++ b/wlauto/core/configuration.py
@@ -639,7 +639,7 @@ class RunConfiguration(object):
         for param, ext in ga.iteritems():
             for name in [ext.name] + [a.name for a in ext.aliases]:
                 self._load_default_config_if_necessary(name)
-                self._raw_config[name][param.name] = value
+                self._raw_config[identifier(name)][param.name] = value
 
     def _set_run_config_item(self, name, value):
         item = self._general_config_map[name]
@@ -653,12 +653,12 @@ class RunConfiguration(object):
     def _set_raw_dict(self, name, value, default_config=None):
         existing_config = self._raw_config.get(name, default_config or {})
         new_config = _merge_config_dicts(existing_config, value)
-        self._raw_config[name] = new_config
+        self._raw_config[identifier(name)] = new_config
 
     def _set_raw_list(self, name, value):
         old_value = self._raw_config.get(name, [])
         new_value = merge_lists(old_value, value, duplicates='last')
-        self._raw_config[name] = new_value
+        self._raw_config[identifier(name)] = new_value
 
     def _finalize_config_list(self, attr_name):
         """Note: the name is somewhat misleading. This finalizes a list
@@ -680,6 +680,7 @@ class RunConfiguration(object):
         self.device_config = config
 
     def _load_default_config_if_necessary(self, name):
+        name = identifier(name)
         if name not in self._raw_config:
             self._raw_config[name] = self.ext_loader.get_default_config(name)
 


### PR DESCRIPTION
Commit 2276ae0c5b54 ("Fixing config processing for extensions with
non-identifier names.") broke customizing the trace-cmd instrumentation
from the agenda.  With an agenda like:

config:
  instrumentation: [trace-cmd, delay]
  trace_events: ['thermal*']
  trace_buffer_size: 28000

trace_events and trace_buffer_size get added to the RunConfiguration's
_raw_config under the trace-cmd name, but then when it's looked up in
_finalize_config_list(), the dictionary is actually looked up using
identifier(extname), i.e. 'trace_cmd'.  Fix this by adding the user's
configuration using identifier(name) as well.