### PR TITLE
get options in config_example.py reachable

### DIFF
--- a/wlauto/config_example.py
+++ b/wlauto/config_example.py
@@ -199,18 +199,6 @@ logging = {
 #hwmon_sensors = ['energy', 'temp']
 
 ####################################################################################################
-##################################### streamline configuration #####################################
-
-# The port number on which gatord will listen
-#port = 8080
-
-# Enabling/disabling the run of 'streamline -analyze' on the captured data.
-#streamline_analyze = True
-
-# Enabling/disabling the generation of a CSV report
-#streamline_report_csv = True
-
-####################################################################################################
 ###################################### trace-cmd configuration #####################################
 
 # trace-cmd events to be traced. The events can be found by rooting on the device then type

--- a/wlauto/instrumentation/daq/__init__.py
+++ b/wlauto/instrumentation/daq/__init__.py
@@ -92,33 +92,42 @@ class Daq(Instrument):
 
     parameters = [
         Parameter('server_host', kind=str, default='localhost',
+                  global_alias='daq_server_host',
                   description='The host address of the machine that runs the daq Server which the '
                               'insturment communicates with.'),
         Parameter('server_port', kind=int, default=56788,
+                  global_alias='daq_server_port',
                   description='The port number for daq Server in which daq insturment communicates '
                               'with.'),
         Parameter('device_id', kind=str, default='Dev1',
+                  global_alias='daq_device_id',
                   description='The ID under which the DAQ is registered with the driver.'),
         Parameter('v_range', kind=float, default=2.5,
+                  global_alias='daq_v_range',
                   description='Specifies the voltage range for the SOC voltage channel on the DAQ '
                               '(please refer to :ref:`daq_setup` for details).'),
         Parameter('dv_range', kind=float, default=0.2,
+                  global_alias='daq_dv_range',
                   description='Specifies the voltage range for the resistor voltage channel on '
                               'the DAQ (please refer to :ref:`daq_setup` for details).'),
         Parameter('sampling_rate', kind=int, default=10000,
+                  global_alias='daq_sampling_rate',
                   description='DAQ sampling rate. DAQ will take this many samples each '
                               'second. Please note that this maybe limitted by your DAQ model '
                               'and then number of ports you\'re measuring (again, see '
                               ':ref:`daq_setup`)'),
         Parameter('resistor_values', kind=list, mandatory=True,
+                  global_alias='daq_resistor_values',
                   description='The values of resistors (in Ohms) across which the voltages are measured on '
                               'each port.'),
         Parameter('channel_map', kind=list_of_ints, default=(0, 1, 2, 3, 4, 5, 6, 7, 16, 17, 18, 19, 20, 21, 22, 23),
+                  global_alias='daq_channel_map',
                   description='Represents mapping from  logical AI channel number to physical '
                               'connector on the DAQ (varies between DAQ models). The default '
                               'assumes DAQ 6363 and similar with AI channels on connectors '
                               '0-7 and 16-23.'),
         Parameter('labels', kind=list_of_strs,
+                  global_alias='daq_labels',
                   description='List of port labels. If specified, the lenght of the list must match '
                               'the length of ``resistor_values``. Defaults to "PORT_<pnum>", where '
                               '"pnum" is the number of the port.')

--- a/wlauto/instrumentation/hwmon/__init__.py
+++ b/wlauto/instrumentation/hwmon/__init__.py
@@ -63,6 +63,7 @@ class HwmonInstrument(Instrument):
 
     parameters = [
         Parameter('sensors', kind=list_of_strs, default=['energy', 'temp'],
+                  global_alias='hwmon_sensors',
                   description='The kinds of sensors hwmon instrument will look for')
     ]
 

--- a/wlauto/instrumentation/perf/__init__.py
+++ b/wlauto/instrumentation/perf/__init__.py
@@ -69,15 +69,18 @@ class PerfInstrument(Instrument):
 
     parameters = [
         Parameter('events', kind=list_of_strs, default=['migrations', 'cs'],
+                  global_alias='perf_events',
                   constraint=(lambda x: x, 'must not be empty.'),
                   description="""Specifies the events to be counted."""),
         Parameter('optionstring', kind=arguments, default='-a',
+                  global_alias='perf_options',
                   description="""Specifies options to be used for the perf command. This
                   may be a list of option strings, in which case, multiple instances of perf
                   will be kicked off -- one for each option string. This may be used to e.g.
                   collected different events from different big.LITTLE clusters.
                   """),
         Parameter('labels', kind=list_of_strs, default=None,
+                  global_alias='perf_labels',
                   description="""Provides labels for pref output. If specified, the number of
                   labels must match the number of ``optionstring``\ s.
                   """),

--- a/wlauto/instrumentation/pmu_logger/__init__.py
+++ b/wlauto/instrumentation/pmu_logger/__init__.py
@@ -60,6 +60,7 @@ class CciPmuLogger(Instrument):
 
     parameters = [
         Parameter('events', kind=list, default=DEFAULT_EVENTS,
+                  global_alias='cci_pmu_events',
                   description="""
                   A list of strings, each representing an event to be counted. The length
                   of the list cannot exceed the number of PMU counters available (4 in CCI-400).
@@ -67,14 +68,17 @@ class CciPmuLogger(Instrument):
                   clusters will be counted by default.  E.g. ``['0x63', '0x83']``.
                   """),
         Parameter('event_labels', kind=list, default=[],
+                  global_alias='cci_pmu_event_labels',
                   description="""
                   A list of labels to be used when reporting PMU counts. If specified,
                   this must be of the same length as ``cci_pmu_events``. If not specified,
                   events will be labeled "event_<event_number>".
                   """),
         Parameter('period', kind=int, default=10,
+                  global_alias='cci_pmu_period',
                   description='The period (in jiffies) between counter reads.'),
         Parameter('install_module', kind=boolean, default=True,
+                  global_alias='cci_pmu_install_module',
                   description="""
                   Specifies whether pmu_logger has been compiled as a .ko module that needs
                   to be installed by the instrument. (.ko binary must be in {}). If this is set


### PR DESCRIPTION
Some options in config_example.py are not reachable. It makes users
confused. So make the options in the file as gobal_alias.

Signed-off-by: zhizhou.zhang <zhizhou.zhang@spreadtrum.com>