### PR TITLE
ipynb_exporter convert to html

### DIFF
--- a/wlauto/utils/ipython.py
+++ b/wlauto/utils/ipython.py
@@ -46,7 +46,7 @@ if IPython:
 
         NotebookNode = IPython.nbformat.NotebookNode  # pylint: disable=E1101
 
-        IPYTHON_NBCONVERT = ['ipython', 'nbconvert', '--to=pdf']
+        IPYTHON_NBCONVERT_PDF = ['ipython', 'nbconvert', '--to=pdf']
     elif StrictVersion(IPython.__version__) >= StrictVersion('2.0.0'):
         import IPython.kernel
         import IPython.nbformat.v3
@@ -59,7 +59,8 @@ if IPython:
 
         NotebookNode = IPython.nbformat.v3.NotebookNode  # pylint: disable=E1101
 
-        IPYTHON_NBCONVERT = ['ipython', 'nbconvert', '--to=latex', '--post=PDF']
+        IPYTHON_NBCONVERT_PDF = ['ipython', 'nbconvert', '--to=latex',
+                                 '--post=PDF']
     else:
         # Unsupported IPython version
         import_error_str = 'Unsupported IPython version {}'.format(IPython.__version__)
@@ -154,7 +155,7 @@ def generate_pdf(nbbasename, output_directory):
     os.chdir(output_directory)
 
     with open(os.devnull, 'w') as devnull:
-        subprocess.check_call(IPYTHON_NBCONVERT + [nbbasename], stderr=devnull)
+        subprocess.check_call(IPYTHON_NBCONVERT_PDF + [nbbasename], stderr=devnull)
 
     os.chdir(prev_dir)
 

--- a/wlauto/utils/ipython.py
+++ b/wlauto/utils/ipython.py
@@ -46,6 +46,7 @@ if IPython:
 
         NotebookNode = IPython.nbformat.NotebookNode  # pylint: disable=E1101
 
+        IPYTHON_NBCONVERT_HTML = ['ipython', 'nbconvert', '--to=html']
         IPYTHON_NBCONVERT_PDF = ['ipython', 'nbconvert', '--to=pdf']
     elif StrictVersion(IPython.__version__) >= StrictVersion('2.0.0'):
         import IPython.kernel
@@ -59,6 +60,7 @@ if IPython:
 
         NotebookNode = IPython.nbformat.v3.NotebookNode  # pylint: disable=E1101
 
+        IPYTHON_NBCONVERT_HTML = ['ipython', 'nbconvert', '--to=html']
         IPYTHON_NBCONVERT_PDF = ['ipython', 'nbconvert', '--to=latex',
                                  '--post=PDF']
     else:
@@ -143,19 +145,28 @@ def run_notebook(notebook):
     kernel_manager.shutdown_kernel()
 
 
-def generate_pdf(nbbasename, output_directory):
-    """Generate a PDF from the ipython notebook
+def export_notebook(nbbasename, output_directory, output_format):
+    """Generate a PDF or HTML from the ipython notebook
+
+    output_format has to be either 'pdf' or 'html'.  These are the
+    only formats currently supported.
 
     ipython nbconvert claims that the CLI is not stable, so keep this
     function here to be able to cope with inconsistencies
 
     """
 
+    if output_format == "html":
+        ipython_command = IPYTHON_NBCONVERT_HTML
+    elif output_format == "pdf":
+        ipython_command = IPYTHON_NBCONVERT_PDF
+    else:
+        raise ValueError("Unknown output format: {}".format(output_format))
+
     prev_dir = os.getcwd()
     os.chdir(output_directory)
 
     with open(os.devnull, 'w') as devnull:
-        subprocess.check_call(IPYTHON_NBCONVERT_PDF + [nbbasename], stderr=devnull)
+        subprocess.check_call(ipython_command + [nbbasename], stderr=devnull)
 
     os.chdir(prev_dir)
-


### PR DESCRIPTION
Add a couple of options to the `ipynb_exporter` so that it can create static html versions of the notebook.