### PR TITLE
passing 'video' command line to Juno kernel

### DIFF
--- a/wlauto/devices/android/juno/__init__.py
+++ b/wlauto/devices/android/juno/__init__.py
@@ -80,7 +80,8 @@ class Juno(BigLittleDevice):
                       'image_args': 'console=ttyAMA0,115200 '
                                     'earlyprintk=pl011,0x7ff80000 '
                                     'verbose debug init=/init '
-                                    'root=/dev/sda1 rw ip=dhcp rootwait',
+                                    'root=/dev/sda1 rw ip=dhcp rootwait'
+                                    'video=DVI-D-1:1920x1080R@60',
                       'fdt_support': True,
                   }
                   ),

--- a/wlauto/devices/android/juno/__init__.py
+++ b/wlauto/devices/android/juno/__init__.py
@@ -80,7 +80,7 @@ class Juno(BigLittleDevice):
                       'image_args': 'console=ttyAMA0,115200 '
                                     'earlyprintk=pl011,0x7ff80000 '
                                     'verbose debug init=/init '
-                                    'root=/dev/sda1 rw ip=dhcp rootwait'
+                                    'root=/dev/sda1 rw ip=dhcp rootwait '
                                     'video=DVI-D-1:1920x1080R@60',
                       'fdt_support': True,
                   }


### PR DESCRIPTION
There's a known issue that HDMI will lose sync with monitor, adding video kernel parameter will make the HDMI more stable for juno

> HDMI can lose sync with the monitor intermittently, particularly at higher resolutions. 
> If you are affected by this then try adding a kernel command line argument that forces 
> a video mode with reduced blanking, such as the following:
> video=DVI-D-1:1920x1080R@60