### PR TITLE
Gem5Device: Fix issue with init arguments

### DIFF
--- a/wlauto/common/gem5/device.py
+++ b/wlauto/common/gem5/device.py
@@ -105,7 +105,7 @@ class BaseGem5Device(object):
         return True
 
     # pylint: disable=E0203
-    def __init__(self, _):
+    def __init__(self):
         self.logger = logging.getLogger('gem5Device')
 
         # The gem5 subprocess

--- a/wlauto/devices/android/gem5/__init__.py
+++ b/wlauto/devices/android/gem5/__init__.py
@@ -89,7 +89,7 @@ class Gem5AndroidDevice(BaseGem5Device, AndroidDevice):
     def __init__(self, **kwargs):
         self.logger = logging.getLogger('Gem5AndroidDevice')
         AndroidDevice.__init__(self, **kwargs)
-        BaseGem5Device.__init__(self, **kwargs)
+        BaseGem5Device.__init__(self)
 
     def login_to_device(self):
         pass

--- a/wlauto/devices/linux/gem5/__init__.py
+++ b/wlauto/devices/linux/gem5/__init__.py
@@ -88,7 +88,7 @@ class Gem5LinuxDevice(BaseGem5Device, LinuxDevice):
     def __init__(self, **kwargs):
         self.logger = logging.getLogger('Gem5LinuxDevice')
         LinuxDevice.__init__(self, **kwargs)
-        BaseGem5Device.__init__(self, **kwargs)
+        BaseGem5Device.__init__(self)
 
     def login_to_device(self):
         # Wait for the login prompt


### PR DESCRIPTION
- This patch addresses an issue with the arguments passed the
  BaseGem5Device __init__. With this patch these are no longer passed
  in as they are not required in the base device implementation.