### PR TITLE
juno: fixing a stupid error in u-boot boot path

### DIFF
--- a/wlauto/devices/android/juno/__init__.py
+++ b/wlauto/devices/android/juno/__init__.py
@@ -106,7 +106,7 @@ class Juno(BigLittleDevice):
         if self.bootloader == 'uefi':
             self._boot_via_uefi()
         else:
-            self._boot_via_uboot(**self.bootargs)
+            self._boot_via_uboot(bootargs=self.bootargs)
 
     def _boot_via_uboot(self, **kwargs):
         if not kwargs:


### PR DESCRIPTION
Juno's bootargs parameter specifies the kernel boot arguments as a
sigle string. However, when it is passed into _boot_via_uboot, it was
expanded as a mapping, causing an error. This fixes that boneheaded
mistake...