### PR TITLE
applaunch: pass cleanup argument to the template

### DIFF
--- a/wlauto/workloads/applaunch/__init__.py
+++ b/wlauto/workloads/applaunch/__init__.py
@@ -106,6 +106,7 @@ class ApplaunchWorkload(Workload):
             wfh.write(template.render(device=self.device,  # pylint: disable=maybe-no-member
                                       sensors=self.sensors,
                                       iterations=self.times,
+                                      cleanup=self.cleanup,
                                       package=APP_CONFIG[self.app]['package'],
                                       activity=APP_CONFIG[self.app]['activity'],
                                       options=APP_CONFIG[self.app]['options'],


### PR DESCRIPTION
Since cleanup test block is defined in the device_script.template, the
value of cleanup is needed to render the template properly.

Signed-off-by: Chase Qi <chase.qi@linaro.org>