### PR TITLE
Parameter: Fixed overriding of new parameters

### DIFF
--- a/wlauto/tests/test_extension.py
+++ b/wlauto/tests/test_extension.py
@@ -324,7 +324,14 @@ class ParametersTest(TestCase):
     def test_duplicate_param_override(self):
         class DuplicateParamExtension(MyBaseExtension):  # pylint: disable=W0612
             parameters = [
-                Parameter('food', override=True, default='cheese'),
+                Parameter('base', override=True, default='buttery'),
+                Parameter('base', override=True, default='biscuit'),
+            ]
+
+    @raises(ValueError)
+    def test_overriding_new_param(self):
+        class DuplicateParamExtension(MyBaseExtension):  # pylint: disable=W0612
+            parameters = [
                 Parameter('food', override=True, default='cheese'),
             ]
 


### PR DESCRIPTION
Previously you could have `override` set to True on parameters that
only existed in the current scope.

Now if you try to override a parameter that doesn't exist higher up
in the hiarchy you will get a ValueError.