### PR TITLE
ApkWorkload: Fixed runtime permission granting

### DIFF
--- a/wlauto/common/android/workload.py
+++ b/wlauto/common/android/workload.py
@@ -22,7 +22,7 @@ from wlauto.core.workload import Workload
 from wlauto.core.resource import NO_ONE
 from wlauto.common.resources import ExtensionAsset, Executable
 from wlauto.exceptions import WorkloadError, ResourceError, ConfigError
-from wlauto.utils.android import ApkInfo
+from wlauto.utils.android import ApkInfo, ANDROID_NORMAL_PERMISSIONS
 from wlauto.utils.types import boolean
 import wlauto.common.android.resources
 
@@ -267,7 +267,10 @@ class ApkWorkload(Workload):
                 break
 
         for permission in permissions:
-            self.device.execute("pm grant {} {}".format(self.package, permission))
+            # "Normal" Permisions are automatically granted and cannot be changed
+            permission_name = permission.rsplit('.', 1)[1]
+            if permission_name not in ANDROID_NORMAL_PERMISSIONS:
+                self.device.execute("pm grant {} {}".format(self.package, permission))
 
     def do_post_install(self, context):
         """ May be overwritten by dervied classes."""

--- a/wlauto/utils/android.py
+++ b/wlauto/utils/android.py
@@ -60,6 +60,44 @@ ANDROID_VERSION_MAP = {
     1: 'BASE',
 }
 
+# See:
+# http://developer.android.com/guide/topics/security/normal-permissions.html
+ANDROID_NORMAL_PERMISSIONS = [
+    'ACCESS_LOCATION_EXTRA_COMMANDS',
+    'ACCESS_NETWORK_STATE',
+    'ACCESS_NOTIFICATION_POLICY',
+    'ACCESS_WIFI_STATE',
+    'BLUETOOTH',
+    'BLUETOOTH_ADMIN',
+    'BROADCAST_STICKY',
+    'CHANGE_NETWORK_STATE',
+    'CHANGE_WIFI_MULTICAST_STATE',
+    'CHANGE_WIFI_STATE',
+    'DISABLE_KEYGUARD',
+    'EXPAND_STATUS_BAR',
+    'GET_PACKAGE_SIZE',
+    'INTERNET',
+    'KILL_BACKGROUND_PROCESSES',
+    'MODIFY_AUDIO_SETTINGS',
+    'NFC',
+    'READ_SYNC_SETTINGS',
+    'READ_SYNC_STATS',
+    'RECEIVE_BOOT_COMPLETED',
+    'REORDER_TASKS',
+    'REQUEST_INSTALL_PACKAGES',
+    'SET_TIME_ZONE',
+    'SET_WALLPAPER',
+    'SET_WALLPAPER_HINTS',
+    'TRANSMIT_IR',
+    'USE_FINGERPRINT',
+    'VIBRATE',
+    'WAKE_LOCK',
+    'WRITE_SYNC_SETTINGS',
+    'SET_ALARM',
+    'INSTALL_SHORTCUT',
+    'UNINSTALL_SHORTCUT',
+]
+
 # TODO: these are set to their actual values near the bottom of the file. There
 # is some HACKery  involved to ensure that ANDROID_HOME does not need to be set
 # or adb added to path for root when installing as root, and the whole


### PR DESCRIPTION
"Normal" android permissions are automatically granted and cannot
be changed. Trying to "pm grant" these caused an error, this should
no longer occur.