### PR TITLE
Add entry_point check for config file existence

### DIFF
--- a/wlauto/core/entry_point.py
+++ b/wlauto/core/entry_point.py
@@ -17,12 +17,13 @@
 import sys
 import argparse
 import logging
+import os
 import subprocess
 import warnings
 
 from wlauto.core.bootstrap import settings
 from wlauto.core.extension_loader import ExtensionLoader
-from wlauto.exceptions import WAError
+from wlauto.exceptions import WAError, ConfigError
 from wlauto.utils.misc import get_traceback
 from wlauto.utils.log import init_logging
 from wlauto.utils.cli import init_argument_parser
@@ -56,6 +57,8 @@ def main():
         settings.verbosity = args.verbose
         settings.debug = args.debug
         if args.config:
+            if not os.path.exists(args.config):
+                raise ConfigError("Config file {} not found".format(args.config))
             settings.update(args.config)
         init_logging(settings.verbosity)
 


### PR DESCRIPTION
This is just to provide a friendlier error message.
Before this commit you get an IOError from imp.load_source.

This only changes the behaviour when using "--config".