### PR TITLE
LinuxDevice: fixed reboot.

### DIFF
--- a/wlauto/utils/ssh.py
+++ b/wlauto/utils/ssh.py
@@ -172,9 +172,8 @@ class SshShell(object):
                         logger.warning('Could not get exit code for "{}",\ngot: "{}"'.format(command, exit_code_text))
                 return output
         except EOF:
-            logger.error('Dropped connection detected.')
             self.connection_lost = True
-            raise
+            raise DeviceError('Connection dropped.')
 
     def logout(self):
         logger.debug('Logging out {}@{}'.format(self.username, self.host))


### PR DESCRIPTION
- Deal with the dropped connection on issuing "reboot"
- Introduced a fixed initial delay before polling for connection to
  avoid re-connecting to adevice that is still in the process of
  shutting down.