### PR TITLE
Executor: WA no longer runs with no workloads specs

### DIFF
--- a/wlauto/commands/run.py
+++ b/wlauto/commands/run.py
@@ -77,6 +77,9 @@ class RunCommand(Command):
             agenda = Agenda(args.agenda)
             settings.agenda = args.agenda
             shutil.copy(args.agenda, settings.meta_directory)
+
+            if len(agenda.workloads) == 0:
+                raise ConfigError("No workloads specified")
         elif '.' in args.agenda or os.sep in args.agenda:
             raise ConfigError('Agenda "{}" does not exist.'.format(args.agenda))
         else:


### PR DESCRIPTION
Previously if no worklaod specs were loaded, WA would still start instruments
and then go immediately to the teardown stage. This no longer happens.