### PR TITLE
cpustates: Fix for error when trying to use cpustates with hotplugged…

### DIFF
--- a/wlauto/result_processors/cpustate.py
+++ b/wlauto/result_processors/cpustate.py
@@ -153,8 +153,12 @@ class CpuStatesProcessor(ResultProcessor):
         cluster_max_freqs = {}
         self.max_freq_list = []
         for c in unique(device.core_clusters):
-            cluster_freqs[c] = device.get_cluster_cur_frequency(c)
-            cluster_max_freqs[c] = device.get_cluster_max_frequency(c)
+            try:
+                cluster_freqs[c] = device.get_cluster_cur_frequency(c)
+                cluster_max_freqs[c] = device.get_cluster_max_frequency(c)
+            except ValueError:
+                cluster_freqs[c] = None
+                cluster_max_freqs[c] = None
         for i, c in enumerate(device.core_clusters):
             self.max_freq_list.append(cluster_max_freqs[c])
             entry = 'CPU {} FREQUENCY: {} kHZ'.format(i, cluster_freqs[c])


### PR DESCRIPTION
… cores

It is not possible to read frequencies form a core that has been hotplugged.
The code will now set the current and max frequencies of hotplugged cores
to None.

This still doesn't work for devices that have dynamic hotplug enabled