### PR TITLE
sysfile_getter/cpufreq: fix taball name

### DIFF
--- a/wlauto/instrumentation/misc/__init__.py
+++ b/wlauto/instrumentation/misc/__init__.py
@@ -57,7 +57,7 @@ class SysfsExtractor(Instrument):
 
     mount_command = 'mount -t tmpfs -o size={} tmpfs {}'
     extract_timeout = 30
-    tarname = 'sysfs.tar.gz'
+    tarname = 'sysfs.tar'
     DEVICE_PATH = 0
     BEFORE_PATH = 1
     AFTER_PATH = 2
@@ -298,7 +298,7 @@ class DynamicFrequencyInstrument(SysfsExtractor):
 
     """
 
-    tarname = 'cpufreq.tar.gz'
+    tarname = 'cpufreq.tar'
 
     parameters = [
         Parameter('paths', mandatory=False, override=True),


### PR DESCRIPTION
Commit 724f6e590e8ba3c2251e864e4216cf258ae7a861 changed sysfile_getter
behavior to first tar up copied files and then gzip them. Tarball name
needs to be updated to not include '.gz' extension.