### PR TITLE
report_power_stats: number of entries returned always matches number of reporters

### DIFF
--- a/wlauto/result_processors/cpustate.py
+++ b/wlauto/result_processors/cpustate.py
@@ -181,7 +181,8 @@ class CpuStatesProcessor(ResultProcessor):
             cpu_utilisation = os.path.join(context.output_directory, 'cpu_utilisation.csv')
         else:
             cpu_utilisation = None
-        parallel_report, powerstate_report = report_power_stats(  # pylint: disable=unbalanced-tuple-unpacking
+
+        reports = report_power_stats(  # pylint: disable=unbalanced-tuple-unpacking
             trace_file=trace.path,
             idle_state_names=self.idle_state_names,
             core_names=self.core_names,
@@ -194,6 +195,9 @@ class CpuStatesProcessor(ResultProcessor):
             cpu_utilisation=cpu_utilisation,
             max_freq_list=self.max_freq_list,
         )
+        parallel_report = reports.pop(0)
+        powerstate_report = reports.pop(0)
+
         if parallel_report is None:
             self.logger.warning('No power state reports generated; are power '
                                 'events enabled in the trace?')

--- a/wlauto/utils/power.py
+++ b/wlauto/utils/power.py
@@ -644,8 +644,7 @@ def report_power_stats(trace_file, idle_state_names, core_names, core_clusters,
     reports = []
     for reporter in reporters:
         report = reporter.report()
-        if report:
-            reports.append(report)
+        reports.append(report)
     return reports
 
 


### PR DESCRIPTION
Previously, only reports that were generated were returned. With this
commit, there will be an entry for each active reporter in the returned
list. If a reporter did not produce a valid report, the entry will be
None.

This ensures consistent output, even if a run time issue causes a
reporter not to produce a report  (e.g. if cpufreq events were not
enabled).