### PR TITLE
LinuxDevice fixes

### DIFF
--- a/wlauto/common/linux/device.py
+++ b/wlauto/common/linux/device.py
@@ -393,7 +393,7 @@ class BaseLinuxDevice(Device):  # pylint: disable=abstract-method
         signal_string = '-s {}'.format(signal) if signal else ''
         self.execute('kill {} {}'.format(signal_string, pid), as_root=as_root)
 
-    def killall(self, process_name, signal=None, as_root=False):  # pylint: disable=W0221
+    def killall(self, process_name, signal=None, as_root=None):  # pylint: disable=W0221
         """
         Kill all processes with the specified name.
 
@@ -404,6 +404,8 @@ class BaseLinuxDevice(Device):  # pylint: disable=abstract-method
         Modified in version 2.1.5: added ``as_root`` parameter.
 
         """
+        if as_root is None:
+            as_root = self.is_rooted
         for pid in self.get_pids_of(process_name):
             self.kill(pid, signal=signal, as_root=as_root)
 
@@ -734,13 +736,15 @@ class LinuxDevice(BaseLinuxDevice):
         except CalledProcessError as e:
             raise DeviceError(e)
 
-    def kick_off(self, command, as_root=False):
+    def kick_off(self, command, as_root=None):
         """
-        Like execute but closes adb session and returns immediately, leaving the command running on the
-        device (this is different from execute(background=True) which keeps adb connection open and returns
+        Like execute but closes ssh session and returns immediately, leaving the command running on the
+        device (this is different from execute(background=True) which keeps ssh connection open and returns
         a subprocess object).
 
         """
+        if as_root is None:
+            as_root = self.is_rooted
         self._check_ready()
         command = 'sh -c "{}" 1>/dev/null 2>/dev/null &'.format(escape_double_quotes(command))
         return self.shell.execute(command, as_root=as_root)

--- a/wlauto/common/linux/device.py
+++ b/wlauto/common/linux/device.py
@@ -685,15 +685,6 @@ class LinuxDevice(BaseLinuxDevice):
 
     # Execution
 
-    def has_root(self):
-        try:
-            self.execute('ls /', as_root=True)
-            return True
-        except DeviceError as e:
-            if 'not in the sudoers file' not in e.message:
-                raise e
-            return False
-
     def execute(self, command, timeout=default_timeout, check_exit_code=True, background=False,
                 as_root=False, strip_colors=True, **kwargs):
         """


### PR DESCRIPTION
- Updated `kick_off` to behave like the Android version
- Updated `killall` to behave like `kick_off` since if something is run as root, root has to kill it/
- Removed unused function `has_root`