### PR TITLE
sysfs_extractor & cpufreq: Fixed error when tar.gz file already existed

### DIFF
--- a/wlauto/instrumentation/misc/__init__.py
+++ b/wlauto/instrumentation/misc/__init__.py
@@ -157,8 +157,8 @@ class SysfsExtractor(Instrument):
                                                               self.tmpfs_mount_point),
                                 as_root=True)
             self.device.execute('chmod 0777 {}'.format(on_device_tarball), as_root=True)
-            self.device.execute('{} gzip {}'.format(self.device.busybox,
-                                                    on_device_tarball))
+            self.device.execute('{} gzip -f {}'.format(self.device.busybox,
+                                                       on_device_tarball))
             self.device.pull_file(on_device_tarball + ".gz", on_host_tarball)
             with tarfile.open(on_host_tarball, 'r:gz') as tf:
                 tf.extractall(context.output_directory)


### PR DESCRIPTION
If the tar.gz already existed on the target device the instruments would
fail. This fix adds the "-f" option to gzip to force it to overwrite the
file.