### PR TITLE
LinuxDevice: error output for pull/push_file

### DIFF
--- a/wlauto/utils/android.py
+++ b/wlauto/utils/android.py
@@ -325,7 +325,6 @@ def adb_shell(device, command, timeout=None, check_exit_code=False, as_root=Fals
             output, _ = check_output(full_command, timeout, shell=True)
         except CalledProcessErrorWithStderr as e:
             output = e.output
-            error = e.error
             exit_code = e.returncode
             if e.returncode == 1:
                 logger.debug("Got Exit code 1, could be either the return code of the command or mean ADB failed")

--- a/wlauto/utils/misc.py
+++ b/wlauto/utils/misc.py
@@ -88,6 +88,12 @@ class CalledProcessErrorWithStderr(CalledProcessError):
         self.error = kwargs.pop("error")
         super(CalledProcessErrorWithStderr, self).__init__(*args, **kwargs)
 
+    def __str__(self):
+        return '{}\nSTDOUT: {}\nSTDERR:{}'.format(CalledProcessError.__str__(self),
+                                                  self.output, self.error)
+
+    __repr__ = __str__
+
 
 def check_output(command, timeout=None, ignore=None, **kwargs):
     """This is a version of subprocess.check_output that adds a timeout parameter to kill

--- a/wlauto/utils/ssh.py
+++ b/wlauto/utils/ssh.py
@@ -26,8 +26,8 @@ import shutil
 from pexpect import EOF, TIMEOUT, spawn, pxssh
 
 from wlauto.exceptions import HostError, DeviceError, TimeoutError, ConfigError
-from wlauto.utils.misc import which, strip_bash_colors, escape_single_quotes, check_output
-
+from wlauto.utils.misc import (which, strip_bash_colors, escape_single_quotes, check_output,
+                               CalledProcessErrorWithStderr)
 
 ssh = None
 scp = None
@@ -243,7 +243,9 @@ class SshShell(object):
         try:
             check_output(command, timeout=timeout, shell=True)
         except subprocess.CalledProcessError as e:
-            raise subprocess.CalledProcessError(e.returncode, e.cmd.replace(pass_string, ''), e.output)
+            raise CalledProcessErrorWithStderr(e.returncode,
+                                               e.cmd.replace(pass_string, ''),
+                                               e.output, getattr(e, 'error', ''))
         except TimeoutError as e:
             raise TimeoutError(e.command.replace(pass_string, ''), e.output)
 


### PR DESCRIPTION
Standard string representation of a subprocess.CalledProcessError does
not include the output of the command, so it was not previsouly included
in the resulting DeviceError. This commit ensures that the output is
propagated, regardless of whether it came from stdout or stderr of the
underlying process.