### PR TITLE
Apk version check

### DIFF
--- a/wlauto/common/android/device.py
+++ b/wlauto/common/android/device.py
@@ -349,18 +349,24 @@ class AndroidDevice(BaseLinuxDevice):  # pylint: disable=W0223
                            timeout=self.default_timeout)
         return bool(int(output))
 
-    def install(self, filepath, timeout=default_timeout, with_name=None):  # pylint: disable=W0221
+    def install(self, filepath, timeout=default_timeout, with_name=None, replace=False):  # pylint: disable=W0221
         ext = os.path.splitext(filepath)[1].lower()
         if ext == '.apk':
-            return self.install_apk(filepath, timeout)
+            return self.install_apk(filepath, timeout, replace)
         else:
             return self.install_executable(filepath, with_name)
 
-    def install_apk(self, filepath, timeout=default_timeout):  # pylint: disable=W0221
+    def install_apk(self, filepath, timeout=default_timeout, replace=False):  # pylint: disable=W0221
         self._check_ready()
         ext = os.path.splitext(filepath)[1].lower()
         if ext == '.apk':
-            return adb_command(self.adb_name, "install '{}'".format(filepath), timeout=timeout)
+            flags = []
+            if replace:
+                flags.append('-r') # Replace existing APK
+            if self.get_sdk_version() >= 23:
+                flags.append('-g') # Grant all runtime permissions
+            self.logger.debug("Replace APK = {}, ADB flags = '{}'".format(replace, ' '.join(flags)))
+            return adb_command(self.adb_name, "install {} '{}'".format(' '.join(flags), filepath), timeout=timeout)
         else:
             raise DeviceError('Can\'t install {}: unsupported format.'.format(filepath))
 

--- a/wlauto/common/android/device.py
+++ b/wlauto/common/android/device.py
@@ -362,9 +362,9 @@ class AndroidDevice(BaseLinuxDevice):  # pylint: disable=W0223
         if ext == '.apk':
             flags = []
             if replace:
-                flags.append('-r') # Replace existing APK
+                flags.append('-r')  # Replace existing APK
             if self.get_sdk_version() >= 23:
-                flags.append('-g') # Grant all runtime permissions
+                flags.append('-g')  # Grant all runtime permissions
             self.logger.debug("Replace APK = {}, ADB flags = '{}'".format(replace, ' '.join(flags)))
             return adb_command(self.adb_name, "install {} '{}'".format(' '.join(flags), filepath), timeout=timeout)
         else:

--- a/wlauto/common/android/resources.py
+++ b/wlauto/common/android/resources.py
@@ -34,3 +34,10 @@ class JarFile(FileResource):
 class ApkFile(FileResource):
 
     name = 'apk'
+
+    def __init__(self, owner, platform=None):
+        super(ApkFile, self).__init__(owner)
+        self.platform = platform
+
+    def __str__(self):
+        return '<{}\'s {} APK>'.format(self.owner, self.platform)

--- a/wlauto/workloads/dex2oat/__init__.py
+++ b/wlauto/workloads/dex2oat/__init__.py
@@ -53,7 +53,8 @@ class Dex2oatBenchmark(Workload):
     def init_resources(self, context):
         # TODO: find a better APK to use for this.
         peacekeeper = ExtensionLoader().get_workload('peacekeeper', self.device)
-        self.apk_file = context.resolver.get(wlauto.common.android.resources.ApkFile(peacekeeper), version='chrome')
+        self.apk_file = context.resolver.get(wlauto.common.android.resources.ApkFile(peacekeeper),
+                                             variant_name='chrome')
         self.package = ApkInfo(self.apk_file).package
 
     def setup(self, context):
@@ -119,4 +120,3 @@ class Dex2oatBenchmark(Workload):
 
     def teardown(self, context):
         self.device.delete_file(self.on_device_oat)
-

--- a/wlauto/workloads/peacekeeper/__init__.py
+++ b/wlauto/workloads/peacekeeper/__init__.py
@@ -63,7 +63,7 @@ class Peacekeeper(AndroidUiAutoBenchmark):
 
     def __init__(self, device, **kwargs):
         super(Peacekeeper, self).__init__(device, **kwargs)
-        self.version = self.browser
+        self.variant_name = self.browser
 
     def update_result(self, context):
         super(Peacekeeper, self).update_result(context)


### PR DESCRIPTION
Opening this for discussion, originally was [this PR](https://github.com/jimboatarm/workload-automation/pull/118)

**Replace APK during install**
 - Use `-g` and `-r` flags with `adb install` if necessary. The `-g` flag is used to grant all runtime permissions at installation time on API 23 and above. The `-r` flag tells `adb` to replace existing APK if found (sometimes uninstall does not fully remove the package e.g. for built-in apps).

**Check APK version and ABI**
 - When the `version` attribute is specified in the workload, the execution will now validate it against the provided APK's `versionName` property, and raise a `WorkloadError` if they do not match.

 - Added `check_apk_abi` parameter to `ApkWorkload` which is disabled by default. If enabled in the workload/agenda, the resource resolver will try to locate the APK in the ABI-specific folder (see note below) and raise an error if not found.
By default (i.e. when disabled), if APK is not found in this path the resolver falls back to the `root` path as per current behaviour.

**Note:**
- The ABI check follows the same principle as that for deploying binary files [described here]
(https://github.com/jimboatarm/workload-automation/blob/master/doc/source/writing_extensions.rst#deploying-executables-to-a-device). Folder path is in the form `<root>/apk/<abi>/<apk_name>`. Where `root` is the base resource location e.g. `~/.workload_automation/dependencies/<extension_name>`.