### PR TITLE
geekbench: fix output files listing

### DIFF
--- a/wlauto/workloads/geekbench/__init__.py
+++ b/wlauto/workloads/geekbench/__init__.py
@@ -122,8 +122,8 @@ class Geekbench(AndroidUiAutoBenchmark):
 
     def update_result_3(self, context):
         outfile_glob = self.device.path.join(self.device.package_data_directory, self.package, 'files', '*gb3')
-        on_device_output_files = [f.strip() for f in
-                                  self.device.execute('ls {}'.format(outfile_glob), as_root=True).split('\n')]
+        on_device_output_files = [f.strip() for f in self.device.execute('ls {}'.format(outfile_glob),
+                                                                         as_root=True).split('\n') if f]
         for i, on_device_output_file in enumerate(on_device_output_files):
             host_temp_file = tempfile.mktemp()
             self.device.pull_file(on_device_output_file, host_temp_file)


### PR DESCRIPTION
After running the benchmark, when collecting the output files the execution
fails because the split('\n') call, used for creating a list of output files,
returns an empty string as last element. The empty string makes the pull command
fail because file '' doesn't exist on the target device.

Signed-off-by: Michele Di Giorgio <michele.digiorgio@arm.com>