### PR TITLE
ssh: fixing rasing of CalledProcessErrorWithStderr

### DIFF
--- a/wlauto/utils/misc.py
+++ b/wlauto/utils/misc.py
@@ -85,6 +85,7 @@ class TimeoutError(Exception):
 class CalledProcessErrorWithStderr(CalledProcessError):
 
     def __init__(self, *args, **kwargs):
+        self.output = kwargs.pop("output")
         self.error = kwargs.pop("error")
         super(CalledProcessErrorWithStderr, self).__init__(*args, **kwargs)
 

--- a/wlauto/utils/ssh.py
+++ b/wlauto/utils/ssh.py
@@ -245,7 +245,8 @@ class SshShell(object):
         except subprocess.CalledProcessError as e:
             raise CalledProcessErrorWithStderr(e.returncode,
                                                e.cmd.replace(pass_string, ''),
-                                               e.output, getattr(e, 'error', ''))
+                                               output=e.output,
+                                               error=getattr(e, 'error', ''))
         except TimeoutError as e:
             raise TimeoutError(e.command.replace(pass_string, ''), e.output)
 


### PR DESCRIPTION
CalledProcessErrorWithStderr is a subclass of CalledProcessError that
also takes stderr output. Both that and normal output must be passed as
keyword arguments. They were being passed as keyword arguments inside
_scp() of SshConnection, causing cryptic errors to appear.