### PR TITLE
Add broadcast_media_mounted method to android device

### DIFF
--- a/wlauto/common/android/device.py
+++ b/wlauto/common/android/device.py
@@ -682,6 +682,13 @@ class AndroidDevice(BaseLinuxDevice):  # pylint: disable=W0223
         except KeyError:
             return None
 
+    def broadcast_media_mounted(self, dirpath):
+        """
+        Force a re-index of the mediaserver cache for the specified directory.
+        """
+        command = 'am broadcast -a android.intent.action.MEDIA_MOUNTED -d file://'
+        self.execute(command + dirpath)
+
     # Internal methods: do not use outside of the class.
 
     def _update_build_properties(self, props):


### PR DESCRIPTION
New method to force a re-index of the mediaserver cache for the
specified directory. Used in workloads that require external media files
as dependencies.