### PR TITLE
Add network check methods to Device and Workload classes

### DIFF
--- a/wlauto/common/android/workload.py
+++ b/wlauto/common/android/workload.py
@@ -86,6 +86,7 @@ class UiAutomatorWorkload(Workload):
             self.uiauto_package = os.path.splitext(os.path.basename(self.uiauto_file))[0]
 
     def setup(self, context):
+        super(UiAutomatorWorkload, self).setup(context)
         method_string = '{}.{}#{}'.format(self.uiauto_package, self.uiauto_class, self.uiauto_method)
         params_dict = self.uiauto_params
         params_dict['workdir'] = self.device.working_directory
@@ -179,6 +180,7 @@ class ApkWorkload(Workload):
         self.logcat_log = None
 
     def setup(self, context):
+        super(ApkWorkload, self).setup(context)
         # Get APK for the correct version and device ABI
         self.apk_file = context.resolver.get(ApkFile(self, self.device.abi),
                                              version=getattr(self, 'version', None),
@@ -363,6 +365,7 @@ class ReventWorkload(Workload):
         self.run_timeout = self.run_timeout or default_run_timeout
 
     def setup(self, context):
+        super(ReventWorkload, self).setup(context)
         self.device.killall('revent')
         command = '{} replay {}'.format(self.on_device_revent_binary, self.on_device_setup_revent)
         self.device.execute(command, timeout=self.setup_timeout)

--- a/wlauto/core/device.py
+++ b/wlauto/core/device.py
@@ -426,6 +426,13 @@ class Device(Extension):
         """
         pass
 
+    def is_network_connected(self):
+        """
+        Checks if the device is connected to the internet
+
+        """
+        raise NotImplementedError()
+
     def __str__(self):
         return 'Device<{}>'.format(self.name)
 

--- a/wlauto/core/workload.py
+++ b/wlauto/core/workload.py
@@ -37,6 +37,7 @@ class Workload(Extension):
     supported_devices = []
     supported_platforms = []
     summary_metrics = []
+    requires_network = False
 
     def __init__(self, device, **kwargs):
         """
@@ -69,7 +70,7 @@ class Workload(Extension):
         """
         pass
 
-    def setup(self, context):
+    def setup(self, context):  # pylint: disable=unused-argument
         """
         Perform the setup necessary to run the workload, such as copying the necessary files
         to the device, configuring the environments, etc.
@@ -78,7 +79,8 @@ class Workload(Extension):
         the workload.
 
         """
-        pass
+        if self.requires_network:
+            self.check_network_connected()
 
     def run(self, context):
         """Execute the workload. This is the method that performs the actual "work" of the"""
@@ -98,6 +100,11 @@ class Workload(Extension):
 
     def finalize(self, context):
         pass
+
+    def check_network_connected(self):
+        if not self.device.is_network_connected():
+            message = 'Workload "{}" requires internet. Device "{}" does not appear to be connected to the internet.'
+            raise WorkloadError(message.format(self.name, self.device.name))
 
     def __str__(self):
         return '<Workload {}>'.format(self.name)


### PR DESCRIPTION
  - Device subclasses should provide their own implementation.
    Default behaviour is to raise a `NotImplementedError`
  - Workload subclasses can set `requires_network` to `True` and
    network connectivity check will be performed during `setup()`