### PR TITLE
workloads: Fixed versions to be backward compatible

### DIFF
--- a/wlauto/workloads/antutu/__init__.py
+++ b/wlauto/workloads/antutu/__init__.py
@@ -48,7 +48,7 @@ class Antutu(AndroidUiAutoBenchmark):
     activity = ".ABenchMarkStart"
     summary_metrics = ['score', 'Overall_Score']
 
-    valid_versions = ['3.3.2', '4.0.3', '5.3', '6.0.1']
+    valid_versions = ['3.3.2', '4.0.3', '5.3', '5.3.0', '6.0.1']
 
     device_prefs_directory = '/data/data/com.antutu.ABenchMark/shared_prefs'
     device_prefs_file = '/'.join([device_prefs_directory, 'com.antutu.ABenchMark_preferences.xml'])
@@ -70,6 +70,8 @@ class Antutu(AndroidUiAutoBenchmark):
 
     def __init__(self, device, **kwargs):  # pylint: disable=W0613
         super(Antutu, self).__init__(device, **kwargs)
+        if self.version == '5.3.0':
+            self.version = '5.3'
         self.run_timeout = 10 * 60 * self.times
         self.uiauto_params['version'] = self.version
         self.uiauto_params['times'] = self.times

--- a/wlauto/workloads/geekbench/__init__.py
+++ b/wlauto/workloads/geekbench/__init__.py
@@ -73,7 +73,8 @@ class Geekbench(AndroidUiAutoBenchmark):
     replace_regex = re.compile(r'<[^>]*>')
 
     parameters = [
-        Parameter('version', default=sorted(versions.keys())[-1], allowed_values=sorted(versions.keys()),
+        Parameter('version', default=sorted(versions.keys())[-1], allowed_values=sorted(versions.keys() +
+                                                                                        ['2', '3']),
                   description='Specifies which version of the workload should be run.'),
         Parameter('times', kind=int, default=1,
                   description=('Specfies the number of times the benchmark will be run in a "tight '
@@ -90,6 +91,10 @@ class Geekbench(AndroidUiAutoBenchmark):
 
     def __init__(self, device, **kwargs):
         super(Geekbench, self).__init__(device, **kwargs)
+        if self.version == '3':
+            self.version = '3.0.0'
+        elif self.version == '2':
+            self.version = '2.2.7'
         self.uiauto_params['version'] = self.version
         self.uiauto_params['times'] = self.times
         self.run_timeout = 5 * 60 * self.times

--- a/wlauto/workloads/glbenchmark/__init__.py
+++ b/wlauto/workloads/glbenchmark/__init__.py
@@ -73,7 +73,7 @@ class Glb(AndroidUiAutoBenchmark):
     regex = re.compile(r'GLBenchmark (metric|FPS): (.*)')
 
     parameters = [
-        Parameter('version', default='2.7', allowed_values=['2.7', '2.5'],
+        Parameter('version', default='2.7', allowed_values=['2.7', '2.7.0', '2.5', '2.5.1'],
                   description=('Specifies which version of the benchmark to run (different versions '
                                'support different use cases).')),
         Parameter('use_case', default=None,
@@ -111,6 +111,10 @@ class Glb(AndroidUiAutoBenchmark):
 
     def __init__(self, device, **kwargs):
         super(Glb, self).__init__(device, **kwargs)
+        if self.version == '2.7.0':
+            self.version = '2.7'
+        elif self.version == '2.5.1':
+            self.version = '2.5'
         self.uiauto_params['version'] = self.version
 
         if self.use_case is None:


### PR DESCRIPTION
In a recent commit workload versions were changed to match their APK versions.
This commit adds the old versions to the allowed versions and automatically
maps them onto the new values.