### PR TITLE
Fixes gitignore to untrack files from uiauto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,9 +14,9 @@ wa_output/
 doc/source/api/
 doc/source/extensions/
 MANIFEST
-wlauto/external/uiautomator/bin/
-wlauto/external/uiautomator/*.properties
-wlauto/external/uiautomator/build.xml
+wlauto/external/uiauto/bin/
+wlauto/external/uiauto/*.properties
+wlauto/external/uiauto/build.xml
 *.orig
 local.properties
 wlauto/external/revent/libs/


### PR DESCRIPTION
Gitignore was untracking a few files from wlauto/external/uiautomator whereas
the folder name is uiauto instead. Name changing done to fix the bug.