### PR TITLE
Revent: Fixes

### DIFF
--- a/doc/source/revent.rst
+++ b/doc/source/revent.rst
@@ -422,10 +422,9 @@ recorded. The event stream is prefixed with the number of events in the stream.
 
 Each event entry structured as follows:
 
- * A signed integer representing which device from the list of device paths
+ * An unsigned integer representing which device from the list of device paths
    this event is for (zero indexed). E.g. Device ID = 3 would be the 4th
    device in the list of device paths.
- * 32 bits of padding
  * A signed integer representing the number of seconds since "epoch" when the
    event was recorded.
  * A signed integer representing the microseconds part of the timestamp.

--- a/wlauto/commands/record.py
+++ b/wlauto/commands/record.py
@@ -157,7 +157,7 @@ class RecordCommand(ReventCommand):
         if args.capture_screen:
             self.logger.info("Recording screen capture")
             self.device.capture_screen(args.output or os.getcwdu())
-        self.device.killall("revent", signal.SIGTERM)
+        self.device.killall("revent", signal.SIGINT)
         self.logger.info("Waiting for revent to finish")
         while self.device.get_pids_of("revent"):
             pass


### PR DESCRIPTION
Changed termination signal to interrupt signal to prevent code exiting too early.
Added exit handler to ensure revent exits correctly as previously was
crashing and therefore not running final code.
Fixed error in writing input event where half of timestamp seconds was missing.
Fixed typo in documentation for revent file structure.