### PR TITLE
NetStat: Updated Regex to match logcat format in android 6.0

### DIFF
--- a/wlauto/instrumentation/netstats/__init__.py
+++ b/wlauto/instrumentation/netstats/__init__.py
@@ -16,7 +16,7 @@ from wlauto.utils.types import list_of_strings
 
 THIS_DIR = os.path.dirname(__file__)
 
-NETSTAT_REGEX = re.compile(r'I/(?P<tag>netstats-\d+)\(\s*\d*\): (?P<ts>\d+) '
+NETSTAT_REGEX = re.compile(r'I[\/ ](?P<tag>netstats-\d+).*?: (?P<ts>\d+) '
                            r'"(?P<package>[^"]+)" TX: (?P<tx>\S+) RX: (?P<rx>\S+)')
 
 


### PR DESCRIPTION
Android marshmallow uses a different default view for logcat
therefore prevented output from being extracted. The regex
expression has been updated to include matching the new format.