### PR TITLE
big.Little Sample Agenda: Fixed workload name and typo.

### DIFF
--- a/wlauto/agenda-example-biglittle.yaml
+++ b/wlauto/agenda-example-biglittle.yaml
@@ -1,6 +1,6 @@
 # This agenda specifies configuration that may be used for regression runs 
-# on big.LITTLE systems. This agenda will with a TC2 device configured as 
-# described in the documentation.
+# on big.LITTLE systems. This agenda will work with a TC2 device configured 
+# as described in the documentation.
 config:
         device: tc2
         run_name: big.LITTLE_regression
@@ -69,7 +69,7 @@ workloads:
         - id: b10
           name: smartbench
         - id: b11
-          name: sqlite
+          name: sqlitebm
         - id: b12
           name: vellamo
 


### PR DESCRIPTION
One of the workloads was listed as sqlite which is an instrument,
corrected the workload name to sqlitebm.

Added missing word in description.