### PR TITLE
Splits ApkWorkload setup() into short methods.

### DIFF
--- a/wlauto/common/android/workload.py
+++ b/wlauto/common/android/workload.py
@@ -204,7 +204,12 @@ class ApkWorkload(Workload):
 
     def setup(self, context):  # pylint: disable=too-many-branches
         Workload.setup(self, context)
+        self.setup_workload_apk(context)
+        self.launch_application()
+        self.kill_background()
+        self.device.clear_logcat()
 
+    def setup_workload_apk(self, context):
         # Get target version
         target_version = self.device.get_installed_package_version(self.package)
         if target_version:
@@ -268,10 +273,12 @@ class ApkWorkload(Workload):
         self.apk_version = self.device.get_installed_package_version(self.package)
         context.add_classifiers(apk_version=self.apk_version)
 
+    def launch_application(self):
         if self.launch_main:
             self.launch_package()  # launch default activity without intent data
+
+    def kill_background(self):
         self.device.execute('am kill-all')  # kill all *background* activities
-        self.device.clear_logcat()
 
     def force_install_apk(self, context, host_version):
         if host_version is None:


### PR DESCRIPTION
Apkworkload setup phase performs many functionalities in
a single method that is broken down into short methods.
The split short methods can be called individually when
relevant use cases arise.