### PR TITLE
Create a function for launching skype application.

### DIFF
--- a/wlauto/workloads/skype/__init__.py
+++ b/wlauto/workloads/skype/__init__.py
@@ -96,4 +96,7 @@ class Skype(AndroidUxPerfWorkload):
 
     def setup(self, context):
         super(Skype, self).setup(context)
+        self.launch_app()
+
+    def launch_app(self):
         self.device.execute('am start -W -a android.intent.action.VIEW -d skype:dummy?dummy')


### PR DESCRIPTION
Skype has a unique launch command which is called in the setup
phase of the workload. The launch command is split into a stand alone
method which can be called as a separate method if required.

This can be used as common method if more applications in future
require their own customized launch command.