### PR TITLE
Applaunch: Update package to measured workload pkg.

### DIFF
--- a/wlauto/workloads/applaunch/__init__.py
+++ b/wlauto/workloads/applaunch/__init__.py
@@ -115,6 +115,7 @@ class Applaunch(AndroidUxPerfWorkload):
         self.workload = loader.get_workload(self.workload_name, self.device,
                                             **self.workload_params)
         self.init_workload_resources(context)
+        self.package = self.workload.package
 
     def init_workload_resources(self, context):
         self.workload.uiauto_file = context.resolver.get(wlauto.common.android.resources.JarFile(self.workload))


### PR DESCRIPTION
Application launch workload runs the package of the workload which is being
instrumented. Fps instrumentation requires the package name and hence the
package name is changed to the workload package name during initialization.

Tested on Huawei Mate8 with fps instrumentation ON.