### PR TITLE
idle: makes sure screen is off if was off before

### DIFF
--- a/wa/workloads/idle.py
+++ b/wa/workloads/idle.py
@@ -63,8 +63,7 @@ class IdleWorkload(Workload):
 
     def setup(self, context):
         if self.target.os == 'android':
-            if self.screen_off:
-                self.old_screen_state = self.target.is_screen_on()
+            self.old_screen_state = self.target.is_screen_on()
             self.target.ensure_screen_is_on()
             self.target.homescreen()
             if self.screen_off:
@@ -89,3 +88,5 @@ class IdleWorkload(Workload):
                 self.target.sleep(1)
         if self.screen_off and self.old_screen_state:
             self.target.ensure_screen_is_on()
+        elif not self.screen_off and not self.old_screen_state:
+            self.target.ensure_screen_is_off()


### PR DESCRIPTION
In the case where the device screen was off prior to the execution of
the workload, but the user did not set screen_off, the screen will be
turned on during the setup. Previously, it would remain on for the
subsequent execution, however the correct behavior is for the workload
to always restore the screen to its previous state.