### PR TITLE
idle: do not attempt to turn off screen on Linux

### DIFF
--- a/wa/workloads/idle.py
+++ b/wa/workloads/idle.py
@@ -88,5 +88,6 @@ class IdleWorkload(Workload):
                 self.target.sleep(1)
         if self.screen_off and self.old_screen_state:
             self.target.ensure_screen_is_on()
-        elif not self.screen_off and not self.old_screen_state:
+        elif (self.target.os == 'android' and
+                not self.screen_off and not self.old_screen_state):
             self.target.ensure_screen_is_off()


### PR DESCRIPTION
In the teardown, if screen_off was not set, only ensure that the
screen is on for Android targets.