### PR TITLE
EntryPoint: Fixes local package being used over system level

### DIFF
--- a/wlauto/core/entry_point.py
+++ b/wlauto/core/entry_point.py
@@ -14,6 +14,7 @@
 #
 
 
+from __future__ import absolute_import
 import sys
 import argparse
 import logging


### PR DESCRIPTION
Due to a local file named 'signal.py' this was being imported instead of the system level 'signal' package. This commit ensures the the system level is used instead.