### PR TITLE
Replaced active_cpus by online_cpus in common/linux/device.py

### DIFF
--- a/wlauto/common/linux/device.py
+++ b/wlauto/common/linux/device.py
@@ -518,10 +518,10 @@ class BaseLinuxDevice(Device):  # pylint: disable=abstract-method
     def get_number_of_online_cores(self, core):
         if core not in self.core_names:
             raise ValueError('Unexpected core: {}; must be in {}'.format(core, list(set(self.core_names))))
-        active_cpus = self.active_cpus
+        online_cpus = self.online_cpus
         num_active_cores = 0
         for i, c in enumerate(self.core_names):
-            if c == core and i in active_cpus:
+            if c == core and i in online_cpus:
                 num_active_cores += 1
         return num_active_cores
 

--- a/wlauto/core/execution.py
+++ b/wlauto/core/execution.py
@@ -642,7 +642,7 @@ class Runner(object):
         job.iteration = self.context.current_iteration
         if job.result.status in self.config.retry_on_status:
             if job.retry >= self.config.max_retries:
-                self.logger.error('Exceeded maxium number of retries. Abandoning job.')
+                self.logger.error('Exceeded maximum number of retries. Abandoning job.')
             else:
                 self.logger.info('Job status was {}. Retrying...'.format(job.result.status))
                 retry_job = RunnerJob(job.spec, job.retry + 1)


### PR DESCRIPTION
I believe `active_cpus` was removed and replaced by `online_cpus` but linux/device.py still seems to reference `active_cpus`

I'm creating the pull request with the fix now, so that our test infrastructure can pick it up and test it.
I'll confirm in a later message whether or not it fixes the issue.