### PR TITLE
Workload: Increased default uiautomator workload timeout

### DIFF
--- a/wlauto/common/android/workload.py
+++ b/wlauto/common/android/workload.py
@@ -74,7 +74,7 @@ class UiAutomatorWorkload(Workload):
     uiauto_method = 'android.support.test.runner.AndroidJUnitRunner'
     # Can be overidden by subclasses to adjust to run time of specific
     # benchmarks.
-    run_timeout = 4 * 60  # seconds
+    run_timeout = 10 * 60  # seconds
 
     def __init__(self, device, _call_super=True, **kwargs):  # pylint: disable=W0613
         if _call_super:


### PR DESCRIPTION
After the upgrade to uiauto2 some workloads seem to take slightly longer
than previously.