### PR TITLE
fps: Ignore additional fields in gfxinfo frame data

### DIFF
--- a/wlauto/instrumentation/fps/__init__.py
+++ b/wlauto/instrumentation/fps/__init__.py
@@ -392,6 +392,8 @@ class LatencyCollector(threading.Thread):
         if match:
             data = match.group(0)[:-1]
             data = map(int, data.split(','))
+            # Ignore additional fields
+            data = data[:len(self.header)]
             frame = GfxInfoFrame(*data)
             if frame not in self.frames:
                 if frame.Flags & GFXINFO_EXEMPT:


### PR DESCRIPTION
Some versions of Android include additional fields in gfinxo which we
don't care about. The existing fields have the same order, so simply
ignore the extra ones.