### PR TITLE
cpustates: fix idle state assumption on freq transition

### DIFF
--- a/wlauto/utils/power.py
+++ b/wlauto/utils/power.py
@@ -212,6 +212,8 @@ class PowerStateProcessor(object):
         self.current_time = event.timestamp
         if event.idle_state is None:
             self.cpu_states[event.cpu_id].frequency = event.frequency
+            if self.cpu_states[event.cpu_id].idle_state is None:
+                self.cpu_states[event.cpu_id].idle_state = -1
         else:
             if event.idle_state == -1:
                 self._process_idle_exit(event)


### PR DESCRIPTION
If a frequency transition is observed before an idle state can be
established, assume idle state is -1 (i.e. the core is running). This
will ensure correct stats for platforms with disabled cpuidle.