### PR TITLE
Revert "cpustates: fix idle state assumption on freq transition"

### DIFF
--- a/wlauto/utils/power.py
+++ b/wlauto/utils/power.py
@@ -212,8 +212,6 @@ class PowerStateProcessor(object):
         self.current_time = event.timestamp
         if event.idle_state is None:
             self.cpu_states[event.cpu_id].frequency = event.frequency
-            if self.cpu_states[event.cpu_id].idle_state is None:
-                self.cpu_states[event.cpu_id].idle_state = -1
         else:
             if event.idle_state == -1:
                 self._process_idle_exit(event)


### PR DESCRIPTION
This reverts commit 9bd745b347ef1a18a8b46a07cf5fa6dd3af642f8.

When a frequency is changed on a core, cpufreq reports a frequency
transition for all cores in the frequency domain. This means it is not
safe to assume a core is not idling just because there is a frequency
transition reported for it (that just means that there is at least one
core on that frequency domain that is not idling). Moreover, the
transitions are always reported in the same order so there is no way to
infer which core triggered it.