### PR TITLE
ApkWorkload: only uninstall if package is already installed

### DIFF
--- a/wlauto/common/android/workload.py
+++ b/wlauto/common/android/workload.py
@@ -414,7 +414,7 @@ class ApkWorkload(Workload):
 
     def install_apk(self, context, replace=False):
         success = False
-        if replace:
+        if replace and self.device.package_is_installed(self.package):
             self.device.uninstall(self.package)
         output = self.device.install_apk(self.apk_file, timeout=self.install_timeout,
                                          replace=replace, allow_downgrade=True)


### PR DESCRIPTION
Attempting to uninstall an non-existing package will result in an error.
So, when replace=True for install_apk(), only attempt to uninstall if
the package is already present on the target.