### PR TITLE
AgendaPaser: fix duplicate source error

### DIFF
--- a/wa/framework/configuration/parsers.py
+++ b/wa/framework/configuration/parsers.py
@@ -114,7 +114,7 @@ class AgendaParser(object):
             if 'run_name' in entry:
                 state.run_config.set('run_name', entry.pop('run_name'))
 
-            state.load_config(entry, source, wrap_exceptions=False)
+            state.load_config(entry, '{}/{}'.format(source, name), wrap_exceptions=False)
 
     def _pop_sections(self, raw):
         sections = raw.pop("sections", [])


### PR DESCRIPTION
When both global and config sections are present in an agenda, they both
will be processed by the ConfigManager. In each case, the path to the
agenda file was specified as the source, which resulted ConfigManager
complaining that the same source is being added twice. To avoid that,
the source is now suffixed with the section name.