### PR TITLE
AndroidDevice: more robust getprop parsing

### DIFF
--- a/wlauto/common/android/device.py
+++ b/wlauto/common/android/device.py
@@ -746,12 +746,10 @@ class AndroidDevice(BaseLinuxDevice):  # pylint: disable=W0223
     # Internal methods: do not use outside of the class.
     def _update_build_properties(self, props):
         try:
-            def strip(somestring):
-                return somestring.strip().replace('[', '').replace(']', '')
-            for line in self.execute("getprop").splitlines():
-                key, value = line.split(':', 1)
-                key = strip(key)
-                value = strip(value)
+            regex = re.compile(r'\[([^\]]+)\]\s*:\s*\[([^\]]+)\]')
+            for match in regex.finditer(self.execute("getprop")):
+                key = match.group(1).strip()
+                value = match.group(2).strip()
                 props[key] = value
         except ValueError:
             self.logger.warning('Could not parse build.prop.')


### PR DESCRIPTION
Ran into a development target on which one of the values in getprop
output contained a new line. Updating getprop parsing logic to handle
such cases by switching to a regex.