### PR TITLE
trace-cmd: remove cpufreq_interactive from default events

### DIFF
--- a/wlauto/instrumentation/trace_cmd/__init__.py
+++ b/wlauto/instrumentation/trace_cmd/__init__.py
@@ -92,7 +92,7 @@ class TraceCmdInstrument(Instrument):
     """
 
     parameters = [
-        Parameter('events', kind=list, default=['sched*', 'irq*', 'power*', 'cpufreq_interactive*'],
+        Parameter('events', kind=list, default=['sched*', 'irq*', 'power*'],
                   global_alias='trace_events',
                   description="""
                   Specifies the list of events to be traced. Each event in the list will be passed to


### PR DESCRIPTION
The interactive governor isn't standard any more (and was
Android-only anyway). Remove this default so you don't get errors for
kernels that don't support it.