### PR TITLE
trace-cmd: Update docstring to reflect removed default events

### DIFF
--- a/wlauto/instrumentation/trace_cmd/__init__.py
+++ b/wlauto/instrumentation/trace_cmd/__init__.py
@@ -54,7 +54,6 @@ class TraceCmdInstrument(Instrument):
         - sched*
         - irq*
         - power*
-        - cpufreq_interactive*
 
     The list of available events can be obtained by rooting and running the following
     command line on the device ::


### PR DESCRIPTION
Commit a533680e49ed (trace-cmd: remove cpufreq_interactive from default events)
did not update the documentation's hard-coded list of default events. Update
them now.