### PR TITLE
AndroidDevice: adjust APK install timeout to 5min

### DIFF
--- a/wlauto/common/android/device.py
+++ b/wlauto/common/android/device.py
@@ -390,7 +390,7 @@ class AndroidDevice(BaseLinuxDevice):  # pylint: disable=W0223
         else:
             return self.install_executable(filepath, with_name)
 
-    def install_apk(self, filepath, timeout=default_timeout, replace=False, allow_downgrade=False):  # pylint: disable=W0221
+    def install_apk(self, filepath, timeout=300, replace=False, allow_downgrade=False):  # pylint: disable=W0221
         self._check_ready()
         ext = os.path.splitext(filepath)[1].lower()
         if ext == '.apk':


### PR DESCRIPTION
install_apk() was using the default timeout of 30 seconds, this can
cause problems for some applications on slower targets. Since
installation is expected to be a long-ish operation, there is not reason
for the timeout to be this short.

This commit adjusts the timetout to 5 minutes, which should be a more
reasonable value for most applications. For some apps with particularly
large APKs, this may not be enough, but in those cases, the default
should already be overriden on per-worload bases.