### PR TITLE
Optimize parsing of trace-cmd output

### DIFF
--- a/wlauto/utils/trace_cmd.py
+++ b/wlauto/utils/trace_cmd.py
@@ -274,20 +274,23 @@ class TraceCmdTrace(object):
                     elif TRACE_MARKER_STOP in line:
                         break
 
-                match = DROPPED_EVENTS_REGEX.search(line)
-                if match:
-                    yield DroppedEventsEvent(match.group('cpu_id'))
-                    continue
-
-                matched = False
-                for rx in [HEADER_REGEX, EMPTY_CPU_REGEX]:
-                    match = rx.search(line)
+                if 'EVENTS DROPPED' in line:
+                    match = DROPPED_EVENTS_REGEX.search(line)
                     if match:
-                        logger.debug(line.strip())
-                        matched = True
-                        break
-                if matched:
-                    continue
+                        yield DroppedEventsEvent(match.group('cpu_id'))
+                        continue
+
+                if line.startswith('version') or line.startswith('cpus') or\
+                        line.startswith('CPU:'):
+                    matched = False
+                    for rx in [HEADER_REGEX, EMPTY_CPU_REGEX]:
+                        match = rx.search(line)
+                        if match:
+                            logger.debug(line.strip())
+                            matched = True
+                            break
+                    if matched:
+                        continue
 
                 # <thread/cpu/timestamp>: <event name>: <event body>
                 parts = line.split(': ', 2)


### PR DESCRIPTION
The combined effect of these optimizations is it reduced the time take to loop
over all events in a trace containing 1.5M events from ~70s to ~11s.

- Not using regex to parse events saves ~39s
- Not parsing event bodies unnecessarily saves ~18s*
- Not matching every line against preamble/dropped events regex's saves ~2s

*The benchmark just looped over events; it did not try to access any fields,
 so no bodies were parsed. A typical script would usually access fields in
 some of the events, so this optimization would not be as impactful, but it
 should still effect a significant saving by not parsing all of event bodies.