### PR TITLE
utils/trace_cmd: fix event parsing

### DIFF
--- a/wlauto/utils/trace_cmd.py
+++ b/wlauto/utils/trace_cmd.py
@@ -308,7 +308,7 @@ class TraceCmdTrace(object):
                     if not found:
                         continue
 
-                thread_string, rest = parts[0].split(' [')
+                thread_string, rest = parts[0].rsplit(' [', 1)
                 cpu_id, ts_string = rest.split('] ')
                 body = parts[2].strip()
 


### PR DESCRIPTION
Make event preamble parsing more robust in cases there are multiple
instances of ' [' (e.g. as part of thread name) by splitting exactly
once from the right. The right-most columns are the timestamp and the
cpu id, and much more restricted (and therefore predictable) in their
formatting.