### PR TITLE
cpufreq: raname get_domain_cpus

### DIFF
--- a/wa/framework/target/runtime_config.py
+++ b/wa/framework/target/runtime_config.py
@@ -622,7 +622,7 @@ class CpufreqRuntimeConfig(RuntimeConfig):
         can still be populated.
         '''
         for cluster_cpu in resolve_unique_domain_cpus('all', self.target):
-            domain_cpus = self.target.cpufreq.get_domain_cpus(cluster_cpu)
+            domain_cpus = self.target.cpufreq.get_related_cpus(cluster_cpu)
             for cpu in domain_cpus:
                 if cpu in self.target.list_online_cpus():
                     supported_cpu_freqs = self.target.cpufreq.list_frequencies(cpu)

--- a/wa/utils/misc.py
+++ b/wa/utils/misc.py
@@ -668,7 +668,7 @@ def resolve_unique_domain_cpus(name, target):
     domain_cpus = []
     for cpu in cpus:
         if cpu not in domain_cpus:
-            domain_cpus = target.cpufreq.get_domain_cpus(cpu)
+            domain_cpus = target.cpufreq.get_related_cpus(cpu)
         if domain_cpus[0] not in unique_cpus:
             unique_cpus.append(domain_cpus[0])
     return unique_cpus


### PR DESCRIPTION
get_domain_cpus() got renamed to get_related_cpus() in devlib to reflect
the cpufreq nomenclature. This commit makes corresponding changes in WA.