### PR TITLE
Types: Fix parameter dict get method

### DIFF
--- a/wlauto/utils/types.py
+++ b/wlauto/utils/types.py
@@ -420,7 +420,7 @@ class ParameterDict(dict):
         return self.__iter__()
 
     def get(self, name):
-        return self[name]
+        return self._decode(dict.get(self, name))
 
     def pop(self, key):
         return self._decode(dict.pop(self, key))


### PR DESCRIPTION
The overridden get method was incorrectly using __getitem__() when decoding the
data instead of get().