### PR TITLE
revent.py: Fix handling of zero-event files

### DIFF
--- a/wlauto/utils/revent.py
+++ b/wlauto/utils/revent.py
@@ -142,9 +142,10 @@ class ReventRecording(object):
                     first = last = events.next()
                 except StopIteration:
                     self._duration = 0
-                for last in events:
-                    pass
-                self._duration = (last.time - first.time).total_seconds()
+                else:
+                    for last in events:
+                        pass
+                    self._duration = (last.time - first.time).total_seconds()
             else:  # not streaming
                 if not self._events:
                     self._duration = 0


### PR DESCRIPTION
Previously the try clause worked to catch StopIteration exceptions correctly,
however upon catching the exception, another statment which set self._duration
to (last.time - first.time) was being run regardless, which defeated the point
of the try clause.

This has been fixed by introducing an else clause to contain said statement.