### PR TITLE
spec2000: fix cpumask for generic

### DIFF
--- a/wlauto/workloads/spec2000/__init__.py
+++ b/wlauto/workloads/spec2000/__init__.py
@@ -15,6 +15,7 @@
 
 
 #pylint: disable=E1101,W0201
+import operator
 import os
 import re
 import string
@@ -278,7 +279,11 @@ class Spec2000(Workload):
             commandspec = CommandSpec()
             commandspec.command = bench.command_template.substitute({'binary': binary})
             commandspec.datadir = datadir
-            commandspec.cpumask = get_cpu_mask(cpumap[cpu])
+            if cpu == 'generic':
+                all_cpus = reduce(operator.add, cpumap.values())
+                commandspec.cpumask = get_cpu_mask(all_cpus)
+            else:
+                commandspec.cpumask = get_cpu_mask(cpumap[cpu])
             cmdspecs.append(commandspec)
         return cmdspecs
 


### PR DESCRIPTION
spec2000 expects binaries to be optimised for particular cores and uses
Device's core_names to figure out which cores the benchmark should run
on.

There is one special case, which is "generic", which is not optimised
for a particular uarch. cpumask for this was resolved the same way,
failing the lookup, resulting in the invalid mask 0x0.

To fix this, "generic" is now handled by specifying the mask for all
available CPUs.