### PR TITLE
utils/ipython: handle nbconvert import

### DIFF
--- a/wlauto/utils/ipython.py
+++ b/wlauto/utils/ipython.py
@@ -37,19 +37,22 @@ NBFORMAT_VERSION = 3
 
 if IPython:
     if LooseVersion('6.0.0') > LooseVersion(IPython.__version__) >= LooseVersion('4.0.0'):
-        import nbformat
-        from jupyter_client.manager import KernelManager
+        try:
+            import nbformat
+            from jupyter_client.manager import KernelManager
 
-        def read_notebook(notebook_in):  # pylint: disable=function-redefined
-            return nbformat.reads(notebook_in, NBFORMAT_VERSION)  # pylint: disable=E1101
+            def read_notebook(notebook_in):  # pylint: disable=function-redefined
+                return nbformat.reads(notebook_in, NBFORMAT_VERSION)  # pylint: disable=E1101
 
-        def write_notebook(notebook, fout):  # pylint: disable=function-redefined
-            nbformat.write(notebook, fout)  # pylint: disable=E1101
+            def write_notebook(notebook, fout):  # pylint: disable=function-redefined
+                nbformat.write(notebook, fout)  # pylint: disable=E1101
 
-        NotebookNode = nbformat.NotebookNode  # pylint: disable=E1101
+            NotebookNode = nbformat.NotebookNode  # pylint: disable=E1101
 
-        IPYTHON_NBCONVERT_HTML = ['jupyter', 'nbconvert', '--to html']
-        IPYTHON_NBCONVERT_PDF = ['jupyter', 'nbconvert', '--to pdf']
+            IPYTHON_NBCONVERT_HTML = ['jupyter', 'nbconvert', '--to html']
+            IPYTHON_NBCONVERT_PDF = ['jupyter', 'nbconvert', '--to pdf']
+        except ImportError:
+            import_error_str = 'Please install "jupyter" as well as "ipython" packages.'
 
     elif LooseVersion('4.0.0') > LooseVersion(IPython.__version__) >= LooseVersion('3.0.0'):
         from IPython.kernel import KernelManager


### PR DESCRIPTION
nbconvert has been split into a separate package and is installed as a
dependency for Jupyter rather than IPython. Add a proper import guard
to prevent issues for those that don't need ipython_converter
functionality, and set the appropriate error message for those that do.