### PR TITLE
trace-cmd: remove cpufreq_interactive from default events

### DIFF
--- a/wa/instrumentation/trace-cmd.py
+++ b/wa/instrumentation/trace-cmd.py
@@ -103,7 +103,7 @@ class TraceCmdInstrument(Instrument):
 
     parameters = [
         Parameter('events', kind=list_of_strings,
-                  default=['sched*', 'irq*', 'power*', 'cpufreq_interactive*'],
+                  default=['sched*', 'irq*', 'power*'],
                   global_alias='trace_events',
                   description="""
                   Specifies the list of events to be traced. Each event in the


### PR DESCRIPTION
The interactive governor isn't standard any more (and was
Android-only anyway). Remove this default so you don't get errors for
kernels that don't support it.