### PR TITLE
framework/workload: Fix resolve_packge_from_target

### DIFF
--- a/wa/framework/workload.py
+++ b/wa/framework/workload.py
@@ -485,7 +485,7 @@ class PackageHandler(object):
         if self.package:
             if not self.target.package_is_installed(self.package):
                 msg = 'Package "{}" cannot be found on the host or device'
-            raise WorkloadError(msg.format(self.package))
+                raise WorkloadError(msg.format(self.package_name))
         else:
             installed_versions = []
             for package in self.owner.package_names:


### PR DESCRIPTION
This currently raises an error undonditionally when self.package is set, fix the
indentation so it only does that if it isn't installed on the target.