### PR TITLE
applaunch: do not attempt to uninstall uiauto apk

### DIFF
--- a/wlauto/common/android/workload.py
+++ b/wlauto/common/android/workload.py
@@ -72,6 +72,7 @@ class UiAutomatorWorkload(Workload):
     # Can be overidden by subclasses to adjust to run time of specific
     # benchmarks.
     run_timeout = 10 * 60  # seconds
+    uninstall_uiauto_apk = True
 
     def __init__(self, device, _call_super=True, **kwargs):  # pylint: disable=W0613
         if _call_super:
@@ -118,7 +119,8 @@ class UiAutomatorWorkload(Workload):
         pass
 
     def teardown(self, context):
-        self.device.uninstall(self.uiauto_package)
+        if self.uninstall_uiauto_apk:
+            self.device.uninstall(self.uiauto_package)
 
     def validate(self):
         if not self.uiauto_file:

--- a/wlauto/workloads/applaunch/__init__.py
+++ b/wlauto/workloads/applaunch/__init__.py
@@ -112,6 +112,10 @@ class Applaunch(AndroidUxPerfWorkload):
         self.workload_params['markers_enabled'] = True
         self.workload = loader.get_workload(self.workload_name, self.device,
                                             **self.workload_params)
+
+        # This workload's uiauto apk will not be installed -- automation will be loaded directly form a path
+        # so do not uninstall during teardown
+        self.workload.uninstall_uiauto_apk = False
         self.init_workload_resources(context)
         self.package = self.workload.package
 


### PR DESCRIPTION
applaunch  users the UI automation of the guest workload to detect
launch completion. However, the guest's automaiton apk is pushed to the
target and loaded via DexLoader; it is never actually installed;
therefore, it should not be uninstalled when running guest's teardown.