### PR TITLE
wa: Add ApkWorkload to default imports

### DIFF
--- a/wa/__init__.py
+++ b/wa/__init__.py
@@ -14,4 +14,4 @@ from wa.framework.plugin import Plugin, Parameter
 from wa.framework.processor import ResultProcessor
 from wa.framework.resource import (NO_ONE, JarFile, ApkFile, ReventFile, File,
                                    Executable)
-from wa.framework.workload import Workload, ApkUiautoWorkload, ReventWorkload
+from wa.framework.workload import Workload, ApkWorkload, ApkUiautoWorkload, ReventWorkload


### PR DESCRIPTION
This is to enable some workloads that are currently out-of-tree.