### PR TITLE
trace-cmd: Enable thermal trace events by default

### DIFF
--- a/wa/instrumentation/trace-cmd.py
+++ b/wa/instrumentation/trace-cmd.py
@@ -103,7 +103,7 @@ class TraceCmdInstrument(Instrument):
 
     parameters = [
         Parameter('events', kind=list_of_strings,
-                  default=['sched*', 'irq*', 'power*'],
+                  default=['sched*', 'irq*', 'power*', 'thermal*'],
                   global_alias='trace_events',
                   description="""
                   Specifies the list of events to be traced. Each event in the


### PR DESCRIPTION
Due to the nature of modern Android devices, in order to usefully
interpret the power* events, you more and more often need to know the
kernel's view of temperature too. Therefore I think enabling the
thermal event group by default makes sense.