### PR TITLE
Add feature to mark workloads unsafe for confidential devices 

### DIFF
--- a/wa/framework/configuration/core.py
+++ b/wa/framework/configuration/core.py
@@ -783,6 +783,19 @@ class RunConfiguration(Configuration):
             export the output to an exeternal location.
             ''',
         ),
+        ConfigurationPoint(
+            'allow_phone_home',
+            kind=bool, default=True,
+            description='''
+            Setting this to ``False`` prevents running any workloads that are marked
+            with 'phones_home', meaning they are at risk of exposing information
+            about the device to the outside world. For example, some benchmark
+            applications upload device data to a database owned by the
+            maintainers.
+
+            This can be used to minimise the risk of accidentally running such
+            workloads when testing confidential devices.
+            '''),
     ]
     configuration = {cp.name: cp for cp in config_points + meta_data}
 

--- a/wa/framework/execution.py
+++ b/wa/framework/execution.py
@@ -411,6 +411,13 @@ class Runner(object):
             self.check_job(job)
 
     def do_run_job(self, job, context):
+        rc = self.context.cm.run_config
+        if job.workload.phones_home and not rc.allow_phone_home:
+            self.logger.warning('Skipping job {} ({}) due to allow_phone_home=False'
+                                .format(job.id, job.workload.name))
+            job.set_status(Status.SKIPPED)
+            return
+
         job.set_status(Status.RUNNING)
         self.send(signal.JOB_STARTED)
 

--- a/wa/framework/execution.py
+++ b/wa/framework/execution.py
@@ -332,7 +332,7 @@ class Executor(object):
 
 class Runner(object):
     """
-    
+
     """
 
     def __init__(self, context, pm):
@@ -419,7 +419,7 @@ class Runner(object):
 
         with signal.wrap('JOB_SETUP', self):
             job.setup(context)
-        
+
         try:
             with signal.wrap('JOB_EXECUTION', self):
                 job.run(context)
@@ -473,7 +473,7 @@ class Runner(object):
         retry_job.retries = job.retries + 1
         retry_job.set_status(Status.PENDING)
         self.context.job_queue.insert(0, retry_job)
-        
+
     def send(self, s):
         signal.send(s, self, self.context)
 

--- a/wa/framework/workload.py
+++ b/wa/framework/workload.py
@@ -39,6 +39,17 @@ class Workload(TargetedPlugin):
 
     kind = 'workload'
 
+    phones_home = False
+    """
+    Set this to True to mark that this workload poses a risk of exposing
+    information to the outside world about the device it runs on. An example of
+    this would be a benchmark application that sends scores and device data to a
+    database owned by the maintainer.
+
+    The user can then set allow_phone_home=False in their configuration to
+    prevent this workload from being run accidentally.
+    """
+
     def init_resources(self, context):
         """
         This method may be used to perform early resource discovery and

--- a/wa/workloads/geekbench/__init__.py
+++ b/wa/workloads/geekbench/__init__.py
@@ -98,6 +98,8 @@ class Geekbench(ApkUiautoWorkload):
 
     is_corporate = False
 
+    phones_home = True
+
     @property
     def activity(self):
         return self.versions[self.version]['activity']


### PR DESCRIPTION
Some workloads, such as Geekbench, may phone home and report data about the
device they are running on. This poses a risk for users that are testing on
unreleased or otherwise confidential devices - perhaps they use a standard
agenda to run a large battery of tests, in which case they may forget to disable
these dangerous workloads.

This provides a mechanism to prevent running those workloads from running by
setting allow_phone_home=False in the user configuration.