### PR TITLE
trace-cmd: Disable creation of trace.txt by default

### DIFF
--- a/wa/instrumentation/trace-cmd.py
+++ b/wa/instrumentation/trace-cmd.py
@@ -136,7 +136,7 @@ class TraceCmdInstrument(Instrument):
                   form the buffer size until set succeeds or size is reduced to
                   1MB.
                   """),
-        Parameter('report', kind=bool, default=True,
+        Parameter('report', kind=bool, default=False,
                   description="""
                   Specifies whether reporting should be performed once the
                   binary trace has been generated.


### PR DESCRIPTION
I don't know of any use for the trace.txt produced by this option,
and it is responsible for most of WA's disk usage. Furthermore it
happens to clash with other tools that have specific requirements for
the format of trace.txt. So I propose disabling it by default.