### PR TITLE
energy_measurement: Ensure 'standard' energy metrics are produced

### DIFF
--- a/wa/instrumentation/energy_measurement.py
+++ b/wa/instrumentation/energy_measurement.py
@@ -290,7 +290,7 @@ class EnergyMeasurement(Instrument):
             # Append the device key to the filename and artifact name, unless
             # it's None (as it will be for backends with only 1
             # devce/instrument)
-            if device is not None:
+            len(self.instruments) > 1:
                 name = 'energy_instrument_output_{}'.format(device)
             else:
                 name = 'energy_instrument_output'
@@ -310,7 +310,7 @@ class EnergyMeasurement(Instrument):
             for meas in derived_measurements:
                 # Append the device key to the metric name, unless it's None (as
                 # it will be for backends with only 1 devce/instrument)
-                if device is not None:
+                if len(self.instruments) > 1:
                     metric_name = '{}_{}'.format(meas.name, device)
                 else:
                     metric_name = meas.name


### PR DESCRIPTION
Where backends have the capability to collect from multiple devlib
Instruments, EnergyMeasurement currently appends 'device' keys to the
names of metrics reported by those Instruments. Where multiple
Instruments are indeed used, it then sums up equivalent metrics to
produce the 'normal' metric without the 'device' keys
appended.

E.g. If you have two ACME 'devices' enabled you will get something
like
'device_total_energy_iio:device0' and
'device_total_energy_iio:device1', which will be summed to produce
'device_total_energy'.

However when only one Instrument is actually instantiated, this is
not needed and not done. Therefore just directly produce the metric
with the name originally given by devlib (i.e. in the example,
'device_total_energy').