### PR TITLE
Improve implementation of 'instrumentation' job spec field

### DIFF
--- a/wa/framework/configuration/core.py
+++ b/wa/framework/configuration/core.py
@@ -1023,7 +1023,7 @@ class JobGenerator(object):
         self.ids_to_run = []
         self.sections = []
         self.workloads = []
-        self._enabled_instruments = set()
+        self._enabled_instruments = toggle_set()
         self._read_enabled_instruments = False
         self.disabled_instruments = []
 

--- a/wa/framework/configuration/execution.py
+++ b/wa/framework/configuration/execution.py
@@ -43,7 +43,7 @@ class ConfigManager(object):
 
     @property
     def enabled_instruments(self):
-        return self.jobs_config.enabled_instruments
+        return self.jobs_config.enabled_instruments.values()
 
     @property
     def job_specs(self):

--- a/wa/framework/configuration/execution.py
+++ b/wa/framework/configuration/execution.py
@@ -34,10 +34,10 @@ class CombinedConfig(object):
 
 class ConfigManager(object):
     """
-    Represents run-time state of WA. Mostly used as a container for loaded 
+    Represents run-time state of WA. Mostly used as a container for loaded
     configuration and discovered plugins.
 
-    This exists outside of any command or run and is associated with the running 
+    This exists outside of any command or run and is associated with the running
     instance of wA itself.
     """
 
@@ -87,7 +87,7 @@ class ConfigManager(object):
         instruments = []
         for name in self.enabled_instruments:
             try:
-                instruments.append(self.get_plugin(name, kind='instrument', 
+                instruments.append(self.get_plugin(name, kind='instrument',
                                                    target=target))
             except NotFoundError:
                 msg = 'Instrument "{}" not found'
@@ -134,7 +134,7 @@ def permute_by_job(specs):
     for spec in specs:
         for i in range(1, spec.iterations + 1):
             yield (spec, i)
- 
+
 
 def permute_by_iteration(specs):
     """
@@ -156,7 +156,7 @@ def permute_by_iteration(specs):
 
     all_tuples = []
     for spec in chain(*groups):
-        all_tuples.append([(spec, i + 1) 
+        all_tuples.append([(spec, i + 1)
                            for i in xrange(spec.iterations)])
     for t in chain(*map(list, izip_longest(*all_tuples))):
         if t is not None:
@@ -182,12 +182,12 @@ def permute_by_section(specs):
 
     all_tuples = []
     for spec in chain(*groups):
-        all_tuples.append([(spec, i + 1) 
+        all_tuples.append([(spec, i + 1)
                            for i in xrange(spec.iterations)])
     for t in chain(*map(list, izip_longest(*all_tuples))):
         if t is not None:
             yield t
- 
+
 
 def permute_randomly(specs):
     """

--- a/wa/framework/instrumentation.py
+++ b/wa/framework/instrumentation.py
@@ -321,7 +321,7 @@ def install(instrument, context):
             raise ValueError(message.format(attr_name, arg_num))
 
         priority = get_priority(attr)
-        logger.debug('\tConnecting %s to %s with priority %s(%d)', attr.__name__, 
+        logger.debug('\tConnecting %s to %s with priority %s(%d)', attr.__name__,
                      SIGNAL_MAP[attr_name], priority.name, priority.value)
 
         mc = ManagedCallback(instrument, attr)


### PR DESCRIPTION
This is basically to allow this:
```
workloads: 
- name: foo     # Run a few iterations with ftrace enabled, for deep debugging
  iterations: 3
- name: foo     # Run a load more iterations with ftrace disabled, so we don't fill up our filers
  iterations: 30
  instrumentation: [~trace-cmd]
```

I'm not sure if this implementation is quite right, in particular it doesn't allow _enabling_ an instrument specifically for a job spec (that currently ends up enabling it for them all) and I'm not sure the cleanest way to do that.. so feedback welcome.