### PR TITLE
 framework: Add bail_on_init_failure run configuration 

### DIFF
--- a/wa/framework/configuration/core.py
+++ b/wa/framework/configuration/core.py
@@ -780,6 +780,19 @@ class RunConfiguration(Configuration):
             ''',
         ),
         ConfigurationPoint(
+            'bail_on_init_failure',
+            kind=bool,
+            default=True,
+            description='''
+            When jobs fail during their main setup and run phases, WA will
+            continue attempting to run the remaining jobs. However, by default,
+            if they fail during their early initialization phase, the entire run
+            will end without continuing to run jobs. Setting this to ``False``
+            means that WA will instead skip all the jobs from the job spec that
+            failed, but continue attempting to run others.
+            '''
+        ),
+        ConfigurationPoint(
             'result_processors',
             kind=toggle_set,
             default=['csv', 'status'],


### PR DESCRIPTION
If a workload fails in `setup` or `run`, we continue with the run. This is an
attempt to have similar behaviour for failure in `initialize`.

If a workload fails in `initialize`, we SKIP all the jobs with the same
ID (i.e. same job spec) under the assumption that their `initialize` will fail
too.

-----

Marked this [RFC] because I don't really know if this is desirable behaviour (seems helpful to me, but maybe I've misunderstood the model), and I'm not sure if I've implemented it right (because Runner has to mutate ExecutionState by overwriting its job_queue)