### PR TITLE
framework/resource: clearer file and exe strings

### DIFF
--- a/wa/framework/resource.py
+++ b/wa/framework/resource.py
@@ -93,7 +93,7 @@ class File(Resource):
         return self.path == path
 
     def __str__(self):
-        return '<{}\'s {} {}>'.format(self.owner, self.kind, self.path)
+        return '<{}\'s {} {} file>'.format(self.owner, self.kind, self.path)
 
 
 class Executable(Resource):
@@ -109,7 +109,7 @@ class Executable(Resource):
         return self.filename == os.path.basename(path)
 
     def __str__(self):
-        return '<{}\'s {} {}>'.format(self.owner, self.abi, self.filename)
+        return '<{}\'s {} {} executable>'.format(self.owner, self.abi, self.filename)
 
 
 class ReventFile(Resource):


### PR DESCRIPTION
Update the File and Executable resource string representations to
actually include the words "file" and "executable" respectively to make
messages containing these representations (e.g. when a resource is not
found) clearer.