### PR TITLE
Utils/Android: Fix missing space in check

### DIFF
--- a/wa/utils/android.py
+++ b/wa/utils/android.py
@@ -44,7 +44,7 @@ class LogcatParser(object):
 
     def parse_line(self, line):
         line = line.strip()
-        if not line or line.startswith('-') or ':' not in line:
+        if not line or line.startswith('-') or ': ' not in line:
             return None
 
         metadata, message = line.split(': ', 1)


### PR DESCRIPTION
Logcat entries are split on a ':' followed by a space so ensure this
is present in the line instead of just a ':'. Some devices have entires
without the trailing space causing an error.