### PR TITLE
Add adb_name as an alias for AdbConnection param

### DIFF
--- a/wa/framework/configuration/core.py
+++ b/wa/framework/configuration/core.py
@@ -1134,4 +1134,13 @@ def create_job_spec(workload_entry, sections, target_manager, plugin_cache,
     return job_spec
 
 
+def get_config_point_map(params):
+    pmap = {}
+    for p in params:
+        pmap[p.name] = p
+        for alias in p.aliases:
+            pmap[alias] = p
+    return pmap
+
+
 settings = MetaConfiguration(os.environ)

--- a/wa/framework/configuration/plugin_cache.py
+++ b/wa/framework/configuration/plugin_cache.py
@@ -19,6 +19,7 @@ from itertools import chain
 from devlib.utils.misc import memoized
 
 from wa.framework import pluginloader
+from wa.framework.configuration.core import get_config_point_map
 from wa.framework.exception import ConfigError
 from wa.framework.target.descriptor import get_target_descriptions
 from wa.utils.types import obj_dict
@@ -140,7 +141,7 @@ class PluginCache(object):
         if name in self.targets:
             return self._get_target_params(name)
         params = self.loader.get_plugin_class(name).parameters
-        return {param.name: param for param in params}
+        return get_config_point_map(params)
 
     def _set_plugin_defaults(self, plugin_name, config):
         cfg_points = self.get_plugin_parameters(plugin_name)
@@ -158,9 +159,7 @@ class PluginCache(object):
 
     def _get_target_params(self, name):
         td = self.targets[name]
-        params = {p.name: p for p in chain(td.target_params, td.platform_params, td.conn_params)}
-        #params['connection_settings'] = {p.name: p for p in td.conn_params}
-        return params
+        return get_config_point_map(chain(td.target_params, td.platform_params, td.conn_params))
 
     # pylint: disable=too-many-nested-blocks, too-many-branches
     def _merge_using_priority_specificity(self, specific_name,

--- a/wa/framework/target/descriptor.py
+++ b/wa/framework/target/descriptor.py
@@ -7,6 +7,7 @@ from devlib import (LinuxTarget, AndroidTarget, LocalLinuxTarget,
                     Gem5Connection)
 
 from wa.framework import pluginloader
+from wa.framework.configuration.core import get_config_point_map
 from wa.framework.exception import PluginLoaderError
 from wa.framework.plugin import Plugin, Parameter
 from wa.framework.target.assistant import LinuxAssistant, AndroidAssistant
@@ -29,16 +30,16 @@ def get_target_descriptions(loader=pluginloader):
 
 
 def instantiate_target(tdesc, params, connect=None, extra_platform_params=None):
-    target_params = {p.name: p for p in tdesc.target_params}
-    platform_params = {p.name: p for p in tdesc.platform_params}
-    conn_params = {p.name: p for p in tdesc.conn_params}
-    assistant_params = {p.name: p for p in tdesc.assistant_params}
+    target_params = get_config_point_map(tdesc.target_params)
+    platform_params = get_config_point_map(tdesc.platform_params)
+    conn_params = get_config_point_map(tdesc.conn_params)
+    assistant_params = get_config_point_map(tdesc.assistant_params)
 
     tp, pp, cp = {}, {}, {}
 
     for supported_params, new_params in (target_params, tp), (platform_params, pp), (conn_params, cp):
         for name, value in supported_params.iteritems():
-            if value.default:
+            if value.default and name == value.name:
                 new_params[name] = value.default
 
     for name, value in params.iteritems():

--- a/wa/framework/target/descriptor.py
+++ b/wa/framework/target/descriptor.py
@@ -261,6 +261,7 @@ GEM5_PLATFORM_PARAMS = [
 CONNECTION_PARAMS = {
     AdbConnection: [
         Parameter('device', kind=str,
+                aliases=['adb_name'],
                 description="""
                 ADB device name
                 """),


### PR DESCRIPTION
- Add support for ConfigurationPoint aliases in configuration parsing.
- Add adb_name  alias fro AdbConnnection's device parameter for backwards
  compatibility with WA2.