### PR TITLE
framework/workload: Fix incorrect regex matching apk filepath

### DIFF
--- a/wa/framework/workload.py
+++ b/wa/framework/workload.py
@@ -765,7 +765,7 @@ class PackageHandler(object):
             message = 'Cannot retrieve "{}" as not installed on Target'
             raise WorkloadError(message.format(package))
         package_info = self.target.execute('pm list packages -f {}'.format(package))
-        apk_path = re.match('package:(.*)=', package_info).group(1)
+        apk_path = re.match('package:(.*)={}'.format(package), package_info).group(1)
         self.target.pull(apk_path, self.owner.dependencies_directory)
 
     def teardown(self):


### PR DESCRIPTION
On some devices an installed apk filepath can contain an '=' character
which was previously used to end the regex match. Now match with the
package name as well to ensure the file path is extracted correctly.