### PR TITLE
framework/target: fix caseless runtime params

### DIFF
--- a/wa/framework/target/runtime_parameter_manager.py
+++ b/wa/framework/target/runtime_parameter_manager.py
@@ -74,12 +74,14 @@ class RuntimeParameterManager(object):
 
     def get_config_for_name(self, name):
         name = caseless_string(name)
-        if name in self.runtime_params:
-            return self.runtime_params[name].rt_config
+        for k, v in self.runtime_params.iteritems():
+            if name == k:
+                return v.rt_config
         return None
 
     def get_cfg_point(self, name):
         name = caseless_string(name)
-        if name in self.runtime_params:
-            return self.runtime_params[name].cfg_point
-        raise ConfigError('Unknown Runtime Parameter: {}'.format(name))
+        for k, v in self.runtime_params.iteritems():
+            if name == k:
+                return v.cfg_point
+        raise ConfigError('Unknown runtime parameter: {}'.format(name))


### PR DESCRIPTION
Fix the setting of runtime parameters when the casing of the parameter in
the agenda does not match the "canonical" casing.

To make the writing of agendas easier, the casing of the parameters is
supposed to be ignored. To achieve this, parameter names are converted to
caseless_string type before they are looked up.

caseless_string's do not work with dicts. Both __contains__ (used for
the "in" operator) and __getitem__ (used for the [] operator) implement
hash-based look up, and it is not possible to have a caseless_string
match against multiple hashes to cover the different casing
possibilities.

So instead, iterate over the items in parameters dict, comparing the
caseless_string name to the key, and returning the value if it matches.