### PR TITLE
resource_getters: Change ExtensionAssetGetter to look in local env

### DIFF
--- a/wlauto/resource_getters/standard.py
+++ b/wlauto/resource_getters/standard.py
@@ -291,7 +291,7 @@ class EnvironmentDependencyGetter(ResourceGetter):
             return path
 
 
-class ExtensionAssetGetter(DependencyFileGetter):
+class ExtensionAssetGetter(EnvironmentDependencyGetter):
 
     name = 'extension_asset'
     resource_type = 'extension_asset'


### PR DESCRIPTION
Previously `ExtensionAssetGetter` subclassed `DependencyFileGetter`,
 commit 6e7087ee88b34af453e20f0d8dda95438c72a8fb changed its
functionality to use a cached location instead of the local resource
location. This commit changes the `ExtensionAssetGetter` to subclass
`EnvironmentDependencyGetter` so it checks the local resource location
again.