### PR TITLE
resource_getters: Add support for matching apks via package name

### DIFF
--- a/wlauto/common/android/resources.py
+++ b/wlauto/common/android/resources.py
@@ -35,10 +35,11 @@ class ApkFile(FileResource):
 
     name = 'apk'
 
-    def __init__(self, owner, platform=None, uiauto=False):
+    def __init__(self, owner, platform=None, uiauto=False, package=None):
         super(ApkFile, self).__init__(owner)
         self.platform = platform
         self.uiauto = uiauto
+        self.package = package
 
     def __str__(self):
         apk_type = 'uiautomator ' if self.uiauto else ''

--- a/wlauto/common/android/workload.py
+++ b/wlauto/common/android/workload.py
@@ -220,7 +220,8 @@ class ApkWorkload(Workload):
             self.logger.debug("Found version '{}' on target device".format(target_version))
 
         # Get host version
-        self.apk_file = context.resolver.get(ApkFile(self, self.device.abi),
+        self.apk_file = context.resolver.get(ApkFile(self, self.device.abi,
+                                                     package=getattr(self, 'package', None)),
                                              version=getattr(self, 'version', None),
                                              variant_name=getattr(self, 'variant_name', None),
                                              strict=False)
@@ -232,7 +233,8 @@ class ApkWorkload(Workload):
 
         # Get host version, primary abi is first, and then try to find supported.
         for abi in self.device.supported_abi:
-            self.apk_file = context.resolver.get(ApkFile(self, abi),
+            self.apk_file = context.resolver.get(ApkFile(self, abi,
+                                                         package=getattr(self, 'package', None)),
                                                  version=getattr(self, 'version', None),
                                                  variant_name=getattr(self, 'variant_name', None),
                                                  strict=False)

--- a/wlauto/resource_getters/standard.py
+++ b/wlauto/resource_getters/standard.py
@@ -565,6 +565,7 @@ def get_from_list_by_extension(resource, filelist, extension, version=None, vari
             filelist = [ff for ff in filelist if version.lower() in os.path.basename(ff).lower()]
     if extension == 'apk':
         filelist = [ff for ff in filelist if not ApkInfo(ff).native_code or resource.platform in ApkInfo(ff).native_code]
+        filelist = [ff for ff in filelist if not resource.package or resource.package == ApkInfo(ff).package]
         filelist = [ff for ff in filelist if resource.uiauto == ('com.arm.wlauto.uiauto' in ApkInfo(ff).package)]
     if len(filelist) == 1:
         return filelist[0]


### PR DESCRIPTION
Allows distinguishing between apks based on the package name specified
in the workload.