### PR TITLE
instrumentation/fps: Fix spaces in SurfaceFlinger.

### DIFF
--- a/wlauto/instrumentation/fps/__init__.py
+++ b/wlauto/instrumentation/fps/__init__.py
@@ -317,7 +317,7 @@ class LatencyCollector(threading.Thread):
                     # Then check for each activity in this list and if there is a match,
                     # process the output. If no command is provided, then always process.
                     if self.list_command:
-                        view_list = self.device.execute(self.list_command).split()
+                        view_list = self.device.execute(self.list_command).replace('\r\n', '\n').replace('\r', '\n').split('\n')
                     for activity in self.activities:
                         if activity in view_list:
                             wfh.write(self.device.execute(self.command_template.format(activity)))


### PR DESCRIPTION
When parsing the SurfaceFlinger list output spaces were used as
separators. Some view names have spaces enclosed.
This would lead to views with spaces in their names not being correctly
detected and as a consequence the fps stats not collected.