### PR TITLE
workloads/exoplayer: handle no orig rotation

### DIFF
--- a/wa/workloads/exoplayer/__init__.py
+++ b/wa/workloads/exoplayer/__init__.py
@@ -214,4 +214,5 @@ class ExoPlayer(ApkWorkload):
     def teardown(self, context):
         super(ExoPlayer, self).teardown(context)
         self.monitor.stop()
-        self.target.set_rotation(self._original_orientation)
+        if self._original_orientation is not None:
+            self.target.set_rotation(self._original_orientation)


### PR DESCRIPTION
Do not attempt to reset rotation in teardown if target did not specify
it before workload execution.