### PR TITLE
commands/create: Remove global section of generated agenda

### DIFF
--- a/wa/commands/create.py
+++ b/wa/commands/create.py
@@ -36,8 +36,7 @@ class CreateAgendaSubcommand(SubCommand):
 
     def execute(self, state, args):
         agenda = OrderedDict()
-        agenda['config'] = OrderedDict(instruments=[], output_processors=[])
-        agenda['global'] = OrderedDict(iterations=args.iterations)
+        agenda['config'] = OrderedDict(augmentations=[], iterations=args.iterations)
         agenda['workloads'] = []
         target_desc = None
 


### PR DESCRIPTION
Move the iterations parameter into the general `config` section so the
`global` section can be removed.