### PR TITLE
framework/workload: fix "no matching package" error

### DIFF
--- a/wa/framework/workload.py
+++ b/wa/framework/workload.py
@@ -709,7 +709,7 @@ class PackageHandler(object):
                     message = 'No matching package found for workload {name} (version {version})'
                 else:
                     message = 'No matching package found for workload {name}'
-                raise WorkloadError(message.format(name=self.name, version=self.version))
+                raise WorkloadError(message.format(name=self.owner.name, version=self.version))
 
         self.pull_apk(self.package_name)
         self.apk_file = context.resolver.get(ApkFile(self.owner,


### PR DESCRIPTION
Fix an issue introduced by commit 42fb3eb

	framework/workload: make "no matching package" message more useful

PackageHandler was incorrectly passing self.name into the error message
instead of self.owner.name.