### PR TITLE
workloads/rt-app: fix

### DIFF
--- a/wa/workloads/rt_app/__init__.py
+++ b/wa/workloads/rt_app/__init__.py
@@ -274,7 +274,7 @@ class RtApp(Workload):
         self.target.execute(tar_command, timeout=300)
         target_path = self.target.path.join(self.target_working_directory, TARBALL_FILENAME)
         host_path = os.path.join(context.output_directory, TARBALL_FILENAME)
-        self.target.pull_file(target_path, host_path, timeout=120)
+        self.target.pull(target_path, host_path, timeout=120)
         with tarfile.open(host_path, 'r:gz') as tf:
             tf.extractall(context.output_directory)
         os.remove(host_path)


### PR DESCRIPTION
Change "pull_file" to "pull" when exacting results. "pull_file" was WA2
API which somehow got missed.