### PR TITLE
setup.py: Add work around for installing pandas

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,9 @@ params = dict(
     license='Apache v2',
     maintainer='ARM Architecture & Technology Device Lab',
     maintainer_email='workload-automation@arm.com',
+    setup_requires=[
+        'numpy'
+    ],
     install_requires=[
         'python-dateutil',  # converting between UTC and local time.
         'pexpect>=3.3',  # Send/receive to/from device


### PR DESCRIPTION
For some reason the automatic install of pandas will fail compilation
due to an issue with numpy. A workaround for this issue is to specify
numpy in `setup_requires` as mentioned in https://github.com/numpy/numpy/issues/2434