### PR TITLE
workloads/hackbench: fix target_binary

### DIFF
--- a/wa/workloads/hackbench/__init__.py
+++ b/wa/workloads/hackbench/__init__.py
@@ -62,7 +62,7 @@ class Hackbench(Workload):
     @once
     def initialize(self, context):
         host_binary = context.resolver.get(Executable(self, self.target.abi, self.binary_name))
-        self.target_binary = self.target.install(host_binary)
+        Hackbench.target_binary = self.target.install(host_binary)
 
     def setup(self, context):
         self.target_output_file = self.target.get_workpath(hackbench_results_txt)


### PR DESCRIPTION
Set target_binary as a class, rather than instance, attribute. This
happens only only once per run, and setting it as instance attribute the
first time, makes it unavailable for subsequent instances of the same
workload.