### PR TITLE
framework/execution: end_run() fix part 2

### DIFF
--- a/wa/framework/execution.py
+++ b/wa/framework/execution.py
@@ -118,8 +118,8 @@ class ExecutionContext(object):
         self.run_state.status = status
         self.run_output.status = status
         self.run_output.info.end_time = datetime.utcnow()
-        self.run_output.info.duration = self.output.info.end_time -\
-                                        self.output.info.start_time
+        self.run_output.info.duration = self.run_output.info.end_time -\
+                                        self.run_output.info.start_time
         self.run_output.write_info()
         self.run_output.write_state()
         self.run_output.write_result()


### PR DESCRIPTION
Missed some "output" references in the previous commit.