### PR TITLE
workload: rt-app fixes

### DIFF
--- a/wa/workloads/rt_app/__init__.py
+++ b/wa/workloads/rt_app/__init__.py
@@ -154,8 +154,6 @@ class RtApp(Workload):
                                                             self.target.abi,
                                                             BINARY_NAME), strict=False)
         RtApp.workgen_script = context.resolver.get(File(self, 'workgen'))
-        if not self.target.is_rooted:  # some use cases require root privileges
-            raise WorkloadError('rt-app requires the target to be rooted.')
         self.target.execute('mkdir -p {}'.format(self.target_working_directory))
         self._deploy_rt_app_binary_if_necessary()
 
@@ -172,10 +170,11 @@ class RtApp(Workload):
 
     def run(self, context):
         self.output = self.target.invoke(self.command,
+                                         in_directory=self.target_working_directory,
                                          on_cpus=self.taskset_mask,
                                          redirect_stderr=True,
                                          timeout=self.timeout,
-                                         as_root=True)
+                                         as_root=self.target.is_rooted)
 
     def update_output(self, context):
         self._pull_rt_app_logs(context)

--- a/wa/workloads/rt_app/__init__.py
+++ b/wa/workloads/rt_app/__init__.py
@@ -173,6 +173,7 @@ class RtApp(Workload):
     def run(self, context):
         self.output = self.target.invoke(self.command,
                                          on_cpus=self.taskset_mask,
+                                         redirect_stderr=True,
                                          timeout=self.timeout,
                                          as_root=True)
 


### PR DESCRIPTION
We redirect stderr to stdout for rt-app to allow us to capture the
output. Also remove requirement for root.