### PR TITLE
Abnormal execution conditions fixes and enhancemens

### DIFF
--- a/wa/__init__.py
+++ b/wa/__init__.py
@@ -10,10 +10,12 @@ from wa.framework.exception import (CommandError, ConfigError, HostError, Instru
 from wa.framework.instrument import (Instrument, very_slow, slow, normal, fast,
                                      very_fast)
 from wa.framework.output import RunOutput, discover_wa_outputs
-from wa.framework.plugin import Plugin, Parameter
 from wa.framework.output_processor import OutputProcessor
+from wa.framework.plugin import Plugin, Parameter
 from wa.framework.resource import (NO_ONE, JarFile, ApkFile, ReventFile, File,
                                    Executable)
+from wa.framework.target.descriptor import (TargetDescriptor, TargetDescription,
+                                            create_target_description, add_description_for_target)
 from wa.framework.workload import (Workload, ApkWorkload, ApkUiautoWorkload,
                                    ApkReventWorkload, UIWorkload, UiautoWorkload,
                                    ReventWorkload)

--- a/wa/__init__.py
+++ b/wa/__init__.py
@@ -2,12 +2,11 @@ from wa.framework import pluginloader, signal
 from wa.framework.command import Command, ComplexCommand, SubCommand
 from wa.framework.configuration import settings
 from wa.framework.configuration.core import Status
-from wa.framework.exception import HostError, JobError, InstrumentError, ConfigError
-from wa.framework.exception import (OutputProcessorError, ResourceError,
-                                    CommandError, ToolError)
-from wa.framework.exception import (WAError, NotFoundError, ValidationError,
-                                    WorkloadError)
-from wa.framework.exception import WorkerThreadError, PluginLoaderError
+from wa.framework.exception import (CommandError, ConfigError, HostError, InstrumentError,
+                                    JobError, NotFoundError, OutputProcessorError,
+                                    PluginLoaderError, ResourceError, TargetError,
+                                    TargetNotRespondingError, TimeoutError, ToolError,
+                                    ValidationError, WAError, WorkloadError, WorkerThreadError)
 from wa.framework.instrument import (Instrument, very_slow, slow, normal, fast,
                                      very_fast)
 from wa.framework.output import RunOutput, discover_wa_outputs

--- a/wa/framework/entrypoint.py
+++ b/wa/framework/entrypoint.py
@@ -107,10 +107,9 @@ def main():
         command = commands[args.command]
         sys.exit(command.execute(config, args))
 
-    except KeyboardInterrupt:
-        logging.info('Got CTRL-C. Aborting.')
+    except KeyboardInterrupt as e:
+        log.log_error(e, logger)
         sys.exit(3)
     except Exception as e:  # pylint: disable=broad-except
-        if not getattr(e, 'logged', None):
-            log.log_error(e, logger)
+        log.log_error(e, logger)
         sys.exit(2)

--- a/wa/framework/exception.py
+++ b/wa/framework/exception.py
@@ -33,6 +33,11 @@ class ValidationError(WAError):
     pass
 
 
+class ExecutionError(WAError):
+    """Error encountered by the execution framework."""
+    pass
+
+
 class WorkloadError(WAError):
     """General Workload error."""
     pass

--- a/wa/framework/execution.py
+++ b/wa/framework/execution.py
@@ -233,9 +233,7 @@ class ExecutionContext(object):
             except WorkloadError as e:
                 job.set_status(Status.FAILED)
                 self.add_event(e.message)
-                if not getattr(e, 'logged', None):
-                    log.log_error(e, self.logger)
-                    e.logged = True
+                log.log_error(e, self.logger)
                 failed_ids.append(job.id)
 
                 if self.cm.run_config.bail_on_init_failure:
@@ -428,9 +426,7 @@ class Runner(object):
         except Exception as e: # pylint: disable=broad-except
             job.set_status(Status.FAILED)
             context.add_event(e.message)
-            if not getattr(e, 'logged', None):
-                log.log_error(e, self.logger)
-                e.logged = True
+            log.log_error(e, self.logger)
             if isinstance(e, ExecutionError):
                 raise e
             elif isinstance(e, TargetError):
@@ -470,9 +466,7 @@ class Runner(object):
                     job.run(context)
             except Exception as e:
                 job.set_status(Status.FAILED)
-                if not getattr(e, 'logged', None):
-                    log.log_error(e, self.logger)
-                    e.logged = True
+                log.log_error(e, self.logger)
                 if isinstance(e, TargetError) or isinstance(e, TimeoutError):
                     context.tm.verify_target_responsive()
                 raise e

--- a/wa/framework/job.py
+++ b/wa/framework/job.py
@@ -115,6 +115,9 @@ class Job(object):
                 self.run_time = datetime.utcnow() - start_time
 
     def process_output(self, context):
+        if not context.tm.is_responsive:
+            self.logger.info('Target unresponsive; not processing job output.')
+            return
         self.logger.info('Processing output for job {} [{}]'.format(self.id, self.iteration))
         if self.status != Status.FAILED:
             with signal.wrap('WORKLOAD_RESULT_EXTRACTION', self, context):
@@ -124,11 +127,17 @@ class Job(object):
                 self.workload.update_output(context)
 
     def teardown(self, context):
+        if not context.tm.is_responsive:
+            self.logger.info('Target unresponsive; not tearing down.')
+            return
         self.logger.info('Tearing down job {} [{}]'.format(self.id, self.iteration))
         with signal.wrap('WORKLOAD_TEARDOWN', self, context):
             self.workload.teardown(context)
 
     def finalize(self, context):
+        if not context.tm.is_responsive:
+            self.logger.info('Target unresponsive; not finalizing.')
+            return
         self.logger.info('Finalizing job {} [{}]'.format(self.id, self.iteration))
         with signal.wrap('WORKLOAD_FINALIZED', self, context):
             self.workload.finalize(context)

--- a/wa/framework/output.py
+++ b/wa/framework/output.py
@@ -72,15 +72,24 @@ class Output(object):
             raise RuntimeError(msg)
         self.result.classifiers = value
 
+    @property
+    def events(self):
+        if self.result is None:
+            return []
+        return self.result.events
+
     def __init__(self, path):
         self.basepath = path
         self.result = None
-        self.events = []
 
     def reload(self):
         try:
-            pod = read_pod(self.resultfile)
-            self.result = Result.from_pod(pod)
+            if os.path.isdir(self.basepath):
+                pod = read_pod(self.resultfile)
+                self.result = Result.from_pod(pod)
+            else:
+                self.result = Result()
+                self.result.status = Status.PENDING
         except Exception as e:
             self.result = Result()
             self.result.status = Status.UNKNOWN

--- a/wa/framework/signal.py
+++ b/wa/framework/signal.py
@@ -19,6 +19,7 @@ This module wraps louie signalling mechanism. It relies on modified version of l
 that has prioritization added to handler invocation.
 
 """
+import sys
 import logging
 from contextlib import contextmanager
 
@@ -298,7 +299,7 @@ def send(signal, sender=dispatcher.Anonymous, *args, **kwargs):
     return dispatcher.send(signal, sender, *args, **kwargs)
 
 
-# This will normally be set to log_error() by init_logging(); see wa.framework/log.py.
+# This will normally be set to log_error() by init_logging(); see wa.utils.log
 # Done this way to prevent a circular import dependency.
 log_error_func = logger.error
 
@@ -337,6 +338,9 @@ def wrap(signal_name, sender=dispatcher.Anonymous,*args, **kwargs):
         yield
         send_func(success_signal, sender, *args, **kwargs)
     finally:
+        exc_type, exc, tb = sys.exc_info()
+        if exc:
+            log_error_func(exc)
         send_func(after_signal, sender, *args, **kwargs)
 
 

--- a/wa/framework/target/descriptor.py
+++ b/wa/framework/target/descriptor.py
@@ -117,10 +117,10 @@ class TargetDescription(object):
 
     def _set(self, attr, vals):
         if vals is None:
-            vals = {}
+            vals = []
         elif isiterable(vals):
-            if not hasattr(vals, 'iteritems'):
-                vals = {v.name: v for v in vals}
+            if hasattr(vals, 'values'):
+                vals = v.values()
         else:
             msg = '{} must be iterable; got "{}"'
             raise ValueError(msg.format(attr, vals))
@@ -374,7 +374,7 @@ CONNECTION_PARAMS['ChromeOsConnection'] = \
         CONNECTION_PARAMS[AdbConnection] + CONNECTION_PARAMS[SshConnection]
 
 
-# name --> ((target_class, conn_class), params_list, defaults, assistant_class)
+# name --> ((target_class, conn_class), params_list, defaults)
 TARGETS = {
     'linux': ((LinuxTarget, SshConnection), COMMON_TARGET_PARAMS, None),
     'android': ((AndroidTarget, AdbConnection), COMMON_TARGET_PARAMS +

--- a/wa/framework/target/manager.py
+++ b/wa/framework/target/manager.py
@@ -1,7 +1,7 @@
 import logging
 
 from wa.framework import signal
-from wa.framework.exception import ExecutionError, TargetError
+from wa.framework.exception import ExecutionError, TargetError, TargetNotRespondingError
 from wa.framework.plugin import Parameter
 from wa.framework.target.descriptor import (get_target_description,
                                             instantiate_target,
@@ -90,8 +90,9 @@ class TargetManager(object):
                 self.logger.info('Target unresponsive; performing hard reset')
                 self.target.reboot(hard=True)
                 self.is_responsive = True
+                raise ExecutionError('Target became unresponsive but was recovered.')
             else:
-                raise ExecutionError('Target unresponsive and hard reset not supported; bailing.')
+                raise TargetNotRespondingError('Target unresponsive and hard reset not supported; bailing.')
 
     def _init_target(self):
         tdesc = get_target_description(self.target_name)

--- a/wa/utils/log.py
+++ b/wa/utils/log.py
@@ -44,28 +44,6 @@ _indent_width = 4
 _console_handler = None
 
 
-class ContextLogger(logging.Logger):
-
-    def __init__(self, name, context=None):
-        super(ContextLogger, self).__init__(name)
-        self.context = context
-
-    def warning(self, message):
-        if self.context:
-            self.context.add_event(message)
-        super(ContextLogger, self).warning(message)
-
-    def warn(self, message):
-        if self.context:
-            self.context.add_event(message)
-        super(ContextLogger, self).warn(message)
-
-    def error(self, message):
-        if self.context:
-            self.context.add_event(message)
-        super(ContextLogger, self).error(message)
-
-
 def init(verbosity=logging.INFO, color=True, indent_with=4,
          regular_fmt='%(levelname)-8s %(message)s',
          verbose_fmt='%(asctime)s %(levelname)-8s %(name)10.10s: %(message)s',
@@ -73,7 +51,6 @@ def init(verbosity=logging.INFO, color=True, indent_with=4,
     global _indent_width, _console_handler
     _indent_width = indent_with
     signal.log_error_func = lambda m: log_error(m, signal.logger)
-    logging.setLoggerClass(ContextLogger)
 
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.DEBUG)
@@ -214,9 +191,9 @@ class ErrorSignalHandler(logging.Handler):
 
     def emit(self, record):
         if record.levelno == logging.ERROR:
-            signal.send(signal.ERROR_LOGGED, self)
+            signal.send(signal.ERROR_LOGGED, self, record)
         elif record.levelno == logging.WARNING:
-            signal.send(signal.WARNING_LOGGED, self)
+            signal.send(signal.WARNING_LOGGED, self, record)
 
 
 class LineFormatter(logging.Formatter):

--- a/wa/utils/log.py
+++ b/wa/utils/log.py
@@ -152,6 +152,13 @@ def dedent():
     _indent_level -= 1
 
 
+def set_indent_level(level):
+    global _indent_level
+    old_level = _indent_level
+    _indent_level = level
+    return old_level
+
+
 def log_error(e, logger, critical=False):
     """
     Log the specified Exception as an error. The Error message will be formatted
@@ -163,13 +170,18 @@ def log_error(e, logger, critical=False):
                level, otherwise it will be logged as ``logging.ERROR``.
 
     """
+    if getattr(e, 'logged', None):
+        return
+
     if critical:
         log_func = logger.critical
     else:
         log_func = logger.error
 
     if isinstance(e, KeyboardInterrupt):
-        log_func('Got CTRL-C. Aborting.')
+        old_level = set_indent_level(0)
+        logger.info('Got CTRL-C. Aborting.')
+        set_indent_level(old_level)
     elif isinstance(e, WAError) or isinstance(e, DevlibError):
         log_func(str(e))
     elif isinstance(e, subprocess.CalledProcessError):

--- a/wa/workloads/rt_app/__init__.py
+++ b/wa/workloads/rt_app/__init__.py
@@ -23,6 +23,8 @@ from subprocess import CalledProcessError
 from wa import Workload, Parameter, Executable, File
 from wa.framework.exception import WorkloadError, ResourceError
 from wa.utils.misc import check_output
+from wa.utils.exec_control import once
+
 
 RAW_OUTPUT_FILENAME = 'raw-output.txt'
 TARBALL_FILENAME = 'rtapp-logs.tar.gz'
@@ -145,6 +147,7 @@ class RtApp(Workload):
                   """),
     ]
 
+    @once
     def initialize(self, context):
         # initialize() runs once per run. setting a class variable to make it
         # available to other instances of the workload
@@ -209,6 +212,7 @@ class RtApp(Workload):
         context.add_metric('error_count', error_count, 'count')
         context.add_metric('crit_count', crit_count, 'count')
 
+    @once
     def finalize(self, context):
         if self.uninstall_on_exit:
             self.target.uninstall(self.target_binary)


### PR DESCRIPTION
This pull request contains some fixes for how WA behaves when the usual
execution flow is interrupted by an unusual event. Specifically,

- Fix the behavior on CTRL-C. Previously, hitting CTRL-C once would interrupt
  execution of the current job but would then move onto the next one, requiring
  mashing it repeatedly for the run to terminate. Now, hitting once will
  interrupt the current job, and finalize the run, skipping the subsequent
  jobs (note: if the job has reached the "run" stage, there would still be an
  attempt to process the output and tear it down).
- Implement the handling of unresponsive targets. A hard reset will be
  performed, if possible, or the run will be terminated, if not.


As a "bonus", the pull request also contains enhancements to the target
description APIs intended to make it easier to add new targets to WA. Up to
this point, in order to add a new target configuration (a "device"), one would
need to create a TargetDescription and implement a TargetDescriptor that would
return it. There are now a couple of helper functions for creating a
description (including one that just wraps an existing Target derivative).