### PR TITLE
Add arm energy probe instrument

### DIFF
--- a/wa/instruments/energy_measurement.py
+++ b/wa/instruments/energy_measurement.py
@@ -18,10 +18,12 @@
 from __future__ import division
 from collections import defaultdict
 import os
+import shutil
 
 from devlib import DerivedEnergyMeasurements
 from devlib.instrument import CONTINUOUS
 from devlib.instrument.energy_probe import EnergyProbeInstrument
+from devlib.instrument.arm_energy_probe import ArmEnergyProbeInstrument
 from devlib.instrument.daq import DaqInstrument
 from devlib.instrument.acmecape import AcmeCapeInstrument
 from devlib.instrument.monsoon import MonsoonInstrument
@@ -153,6 +155,37 @@ class EnergyProbeBackend(EnergyInstrumentBackend):
                 msg = 'Number of Energy Probe port labels does not match the number of resistor values.'
                 raise ConfigError(msg)
 
+class ArmEnergyProbeBackend(EnergyInstrumentBackend):
+
+    name = 'arm_energy_probe'
+
+    parameters = [
+        Parameter('config_file', kind=str,
+                  description="""
+                  Path to config file of the AEP
+                  """),
+    ]
+
+    instrument = ArmEnergyProbeInstrument
+
+    def get_instruments(self, target, metadir, **kwargs):
+        """
+        Get a dict mapping device keys to an Instruments
+
+        Typically there is just a single device/instrument, in which case the
+        device key is arbitrary.
+        """
+
+        shutil.copy(self.config_file, metadirr)
+
+        return {None: self.instrument(target, **kwargs)}
+
+    def validate_parameters(self, params):
+        if not params.get('config_file'):
+            raise ConfigError('Mandatory parameter "config_file" is not set.')
+        self.config_file = params.get('config_file')
+        if not os.path.exists(self.config_file):
+            raise ConfigError('"config_file" does not exist.')
 
 class AcmeCapeBackend(EnergyInstrumentBackend):
 
@@ -240,7 +273,7 @@ class EnergyMeasurement(Instrument):
 
     parameters = [
         Parameter('instrument', kind=str, mandatory=True,
-                  allowed_values=['daq', 'energy_probe', 'acme_cape', 'monsoon', 'juno_readenergy'],
+                  allowed_values=['daq', 'energy_probe', 'acme_cape', 'monsoon', 'juno_readenergy', 'arm_energy_probe'],
                   description="""
                   Specify the energy instruments to be enabled.
                   """),

--- a/wa/instruments/energy_measurement.py
+++ b/wa/instruments/energy_measurement.py
@@ -49,7 +49,7 @@ class EnergyInstrumentBackend(Plugin):
     def validate_parameters(self, params):
         pass
 
-    def get_instruments(self, target, **kwargs):
+    def get_instruments(self, target, metadir, **kwargs):
         """
         Get a dict mapping device keys to an Instruments
 
@@ -178,7 +178,7 @@ class AcmeCapeBackend(EnergyInstrumentBackend):
                   """),
     ]
 
-    def get_instruments(self, target,
+    def get_instruments(self, target, metadir,
                         iio_capture, host, iio_devices, buffer_size):
 
         #
@@ -289,7 +289,7 @@ class EnergyMeasurement(Instrument):
         self.backend.validate_parameters(self.params)
 
     def initialize(self, context):
-        self.instruments = self.backend.get_instruments(self.target, **self.params)
+        self.instruments = self.backend.get_instruments(self.target, context.run_output.metadir, **self.params)
 
         for instrument in self.instruments.itervalues():
             if not (instrument.mode & CONTINUOUS):


### PR DESCRIPTION
Arm Energy Probe with arm_probe has been recently added in devlib's instrument.
Add the arm_energy_probe in the WA list of Energy measurement instruments

Signed-off-by: Vincent Guittot <vincent.guittot@linaro.org>