### PR TITLE
fw/workload: Fix installed apk info

### DIFF
--- a/wa/framework/workload.py
+++ b/wa/framework/workload.py
@@ -780,9 +780,8 @@ class PackageHandler(object):
         if not self.target.package_is_installed(package):
             message = 'Cannot retrieve "{}" as not installed on Target'
             raise WorkloadError(message.format(package))
-        package_info = self.target.execute('pm list packages -f {}'.format(package))
-        apk_path = re.match('package:(.*)={}'.format(package), package_info).group(1)
-        self.target.pull(apk_path, self.owner.dependencies_directory)
+        package_info = self.target.get_package_info(package)
+        self.target.pull(package_info.apk_path, self.owner.dependencies_directory)
 
     def teardown(self):
         self.target.execute('am force-stop {}'.format(self.apk_info.package))


### PR DESCRIPTION
Fix an issue where AndroidWorkload.pull_apk would sometimes get the
wrong package if the desired package name is a substring of another
package name. Rather than using a regex to match the package name, use
the new get_package_info method to match the name exactly.

Replies on https://github.com/ARM-software/devlib/pull/250