### PR TITLE
utils/doc: Adds support for showing aliases when formatting parameters

### DIFF
--- a/wa/utils/doc.py
+++ b/wa/utils/doc.py
@@ -274,6 +274,10 @@ def get_params_rst(parameters):
                                       param.mandatory and '(mandatory)' or ' ')
         desc = strip_inlined_text(param.description or '')
         text += indent('{}\n'.format(desc))
+        if param.aliases:
+            text += indent('\naliases: {}\n'.format(', '.join(map(format_literal, param.aliases))))
+        if param.global_alias:
+            text += indent('\nglobal alias: {}\n'.format(format_literal(param.global_alias)))
         if param.allowed_values:
             text += indent('\nallowed values: {}\n'.format(', '.join(map(format_literal, param.allowed_values))))
         elif param.constraint:


### PR DESCRIPTION
Now displays all available local and global aliases when generating the
rst for a parameter.