### PR TITLE
aep: fix variable typo

### DIFF
--- a/wa/instruments/energy_measurement.py
+++ b/wa/instruments/energy_measurement.py
@@ -185,7 +185,7 @@ class ArmEnergyProbeBackend(EnergyInstrumentBackend):
         device key is arbitrary.
         """
 
-        shutil.copy(self.config_file, metadirr)
+        shutil.copy(self.config_file, metadir)
 
         return {None: self.instrument(target, **kwargs)}
 


### PR DESCRIPTION
something wrong has happened when preparing the patch to add
arm-probe AEP support.

Signed-off-by: Vincent Guittot <vincent.guittot@linaro.org>