### PR TITLE
doc: rename update_result

### DIFF
--- a/doc/build_instrumentation_method_map.py
+++ b/doc/build_instrumentation_method_map.py
@@ -22,9 +22,6 @@ from wlauto.core.instrumentation import SIGNAL_MAP, PRIORITY_MAP
 from wlauto.utils.doc import format_simple_table
 
 
-CONVINIENCE_ALIASES = ['initialize', 'setup', 'start', 'stop', 'process_workload_result',
-                       'update_result', 'teardown', 'finalize']
-
 OUTPUT_TEMPLATE_FILE =  os.path.join(os.path.dirname(__file__), 'source', 'instrumentation_method_map.template')
 
 

--- a/doc/source/conventions.rst
+++ b/doc/source/conventions.rst
@@ -45,9 +45,9 @@ dropped. E.g.  ::
 
         # ...
 
-        def update_result(self, context):
+        def update_output(self, context):
            # ...
-           context.result.add_metric('energy', 23.6, 'Joules', lower_is_better=True)
+           context.add_metric('energy', 23.6, 'Joules', lower_is_better=True)
 
         # ...
 

--- a/doc/source/instrumentation_method_map.rst
+++ b/doc/source/instrumentation_method_map.rst
@@ -15,7 +15,7 @@ setup                                    successful-workload-setup-signal
 start                                    before-workload-execution-signal         
 stop                                     after-workload-execution-signal          
 process_workload_result                  successful-iteration-result-update-signal
-update_result                            after-iteration-result-update-signal     
+update_output                            after-workload-output-update-signal
 teardown                                 after-workload-teardown-signal           
 finalize                                 run-fin-signal                           
 on_run_start                             start-signal                             

--- a/doc/source/writing_extensions.rst
+++ b/doc/source/writing_extensions.rst
@@ -387,9 +387,6 @@ The Workload class defines the following interface::
         def setup(self, context):
             pass
 
-        def setup(self, context):
-            pass
-
         def run(self, context):
             pass
 

--- a/doc/source/writing_extensions.rst
+++ b/doc/source/writing_extensions.rst
@@ -390,7 +390,7 @@ The Workload class defines the following interface::
         def run(self, context):
             pass
 
-        def update_result(self, context):
+        def update_output(self, context):
             pass
 
         def teardown(self, context):
@@ -440,7 +440,7 @@ The interface should be implemented as follows
                     copying files to/from the device should be done elsewhere if
                     possible.
 
-    :update_result: This method gets invoked after the task execution has
+    :update_output: This method gets invoked after the task execution has
                     finished and should be used to extract metrics and add them
                     to the result (see below).
     :teardown: This could be used to perform any cleanup you may wish to do,
@@ -458,13 +458,13 @@ Workload methods (except for ``validate``) take a single argument that is a
 track of the current execution state (such as the current workload, iteration
 number, etc), and contains, among other things, a
 :class:`wlauto.core.workload.WorkloadResult` instance that should be populated
-from the ``update_result`` method with the results of the execution. ::
+from the ``update_output`` method with the results of the execution. ::
 
         # ...
 
-        def update_result(self, context):
+        def update_output(self, context):
            # ...
-           context.result.add_metric('energy', 23.6, 'Joules', lower_is_better=True)
+           context.add_metric('energy', 23.6, 'Joules', lower_is_better=True)
 
         # ...
 
@@ -517,7 +517,7 @@ file of a particular size on the device.
                                                                         self.device_infile,
                                                                         self.device_outfile))
 
-        def update_result(self, context):
+        def update_output(self, context):
                 # Pull the results file to the host
                 host_outfile = os.path.join(context.output_directory, 'outfile')
                 self.device.pull(self.device_outfile, host_outfile)
@@ -526,7 +526,7 @@ file of a particular size on the device.
                 content = iter(open(host_outfile).read().strip().split())
                 for value, metric in zip(content, content):
                 mins, secs = map(float, value[:-1].split('m'))
-                context.result.add_metric(metric, secs + 60 * mins)
+                context.add_metric(metric, secs + 60 * mins)
 
         def teardown(self, context):
                 # Clean up on-device file.
@@ -632,7 +632,7 @@ the following interface::
         def stop(self, context):
             pass
 
-        def update_result(self, context):
+        def update_output(self, context):
             pass
 
         def teardown(self, context):
@@ -716,9 +716,9 @@ Below is a simple instrument that measures the execution time of a workload::
         def fast_stop(self, context):
             self.end_time = time.time()
 
-        def update_result(self, context):
+        def update_output(self, context):
             execution_time = self.end_time - self.start_time
-            context.result.add_metric('execution_time', execution_time, 'seconds')
+            context.add_metric('execution_time', execution_time, 'seconds')
 
 
 Adding a Result Processor


### PR DESCRIPTION
In WA3, `update_result()` is called `update_output()`.  Fix the instances in the documentation where this is mentioned.