### PR TITLE
framework/getters: Ignore connection errors with HTTP getter

### DIFF
--- a/wa/framework/getters.py
+++ b/wa/framework/getters.py
@@ -203,7 +203,7 @@ class Http(ResourceGetter):
     def __init__(self, **kwargs):
         super(Http, self).__init__(**kwargs)
         self.logger = logger
-        self.index = None
+        self.index = {}
 
     def register(self, resolver):
         resolver.register(self.get, SourcePriority.remote)
@@ -212,7 +212,12 @@ class Http(ResourceGetter):
         if not resource.owner:
             return  # TODO: add support for unowned resources
         if not self.index:
-            self.index = self.fetch_index()
+            try:
+                self.index = self.fetch_index()
+            except requests.exceptions.RequestException as e:
+                msg = 'Skipping HTTP getter due to connection error: {}'
+                self.logger.debug(msg.format(e.message))
+                return
         if resource.kind == 'apk':
             # APKs must always be downloaded to run ApkInfo for version
             # information.


### PR DESCRIPTION
If the http getter is used but a connection is not avalible, when
attempting to fetch the resource index an error will be raised. Now we
ignore the error allowing for the remaining getters to be used.