### PR TITLE
fw/config: ensure params are obj_dict's

### DIFF
--- a/wa/framework/configuration/core.py
+++ b/wa/framework/configuration/core.py
@@ -865,6 +865,12 @@ class JobSpec(Configuration):
     def finalize(self):
         self.id = "-".join([source.config['id']
                             for source in self._sources[1:]])  # ignore first id, "global"
+
+        # ensure *_parameters are always obj_dict's
+        self.boot_parameters = obj_dict((self.boot_parameters or {}).items())
+        self.runtime_parameters = obj_dict((self.runtime_parameters or {}).items())
+        self.workload_parameters = obj_dict((self.workload_parameters or {}).items())
+
         if self.label is None:
             self.label = self.workload_name
 


### PR DESCRIPTION
As part of finalizing a job spec, ensure all *_parameters are
obj_dict's.