### PR TITLE
wlauto/utils/ssh.py: Fix set terminal window size

### DIFF
--- a/wlauto/utils/ssh.py
+++ b/wlauto/utils/ssh.py
@@ -66,8 +66,14 @@ def ssh_get_shell(host, username, password=None, keyfile=None, port=None, timeou
                 raise DeviceError(message.format(host))
             time.sleep(5)
 
+    conn.sendline('shopt -s checkwinsize')
+    conn.prompt()
     conn.setwinsize(500,200)
     conn.sendline('')
+    conn.prompt()
+    conn.sendline('stty rows 500')
+    conn.prompt()
+    conn.sendline('stty cols 200')
     conn.prompt()
     conn.setecho(False)
     return conn


### PR DESCRIPTION
Ensure that the terminal window size is set to 500x200, if not long
commands (prompt + command > 80 chars) will fail because the pexpect
search to match the command string in order to get the result and the
command is wrapped to first 80 chars.

For example, when check a file and executes:

...
if [ -f '/sys/kernel/debug/sched_features' ]; then echo 1; else echo 0; fi
...
File
\"/usr/local/lib/python2.7/dist-packages/wlauto/common/linux/device.py\",
line 228, in get_properties
if self.is_file(propfile):
File
\"/usr/local/lib/python2.7/dist-packages/wlauto/common/linux/device.py\",
line 215, in is_file
return boolean(output.split()[-1])  # pylint: disable=maybe-no-member

IndexError(list index out of range)
...

In order to fix this scenario enables checkwinsize in the shell and use
stty to set the new terminal window size.

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>