### PR TITLE
config/execution: Raise better error if no workloads specified.

### DIFF
--- a/wa/framework/configuration/parsers.py
+++ b/wa/framework/configuration/parsers.py
@@ -87,6 +87,10 @@ class AgendaParser(object):
             self._populate_and_validate_config(state, raw, source)
             sections = self._pop_sections(raw)
             global_workloads = self._pop_workloads(raw)
+            if not global_workloads:
+                msg = 'No jobs avaliable. Please ensure you have specified at '\
+                      'least one workload to run.'
+                raise ConfigError(msg)
 
             if raw:
                 msg = 'Invalid top level agenda entry(ies): "{}"'


### PR DESCRIPTION
If WA is ran without any workloads being specified previously an index
Error was thrown, now check to see if jobs have been generated and if
not provide a more helpful error message.