### PR TITLE
framework/config: add disable all augmentations

### DIFF
--- a/wa/framework/configuration/parsers.py
+++ b/wa/framework/configuration/parsers.py
@@ -306,6 +306,8 @@ def _construct_valid_entry(raw, seen_ids, prefix, jobs_config):
             workload_entry[name] = value
 
     if "augmentations" in workload_entry:
+        workload_entry["augmentations"] = \
+            jobs_config.process_disable_all_glyph(workload_entry["augmentations"])
         jobs_config.update_augmentations(workload_entry["augmentations"])
 
     # error if there are unknown workload_entry


### PR DESCRIPTION
Add glyph `~~` to be used in the configuration to disable all
augmentations specified at a lower configuration level.

Also useable with the `--disable` argument to disable all augmentations.