### PR TITLE
Do not lose early logging

### DIFF
--- a/doc/source/user_reference/configuration.rst
+++ b/doc/source/user_reference/configuration.rst
@@ -50,5 +50,15 @@ various assets when it starts.
    .. note:: This location **must** be writable by the user who runs WA.
 
 
+.. confval:: WA_LOG_BUFFER_CAPACITY
+
+    Specifies the capacity (in log records) for the early log handler which is
+    used to buffer log records until a log file becomes available. If the is not
+    set, the default value of ``1000`` will be used. This should sufficient for
+    most scenarios, however this may need to be increased, e.g. if plugin loader
+    scans a very large number of locations; this may also be set to a lower
+    value to reduce WA's memory footprint on memory-constrained hosts.
+
+
 .. include:: user_reference/runtime_parameters.rst
 

--- a/wa/commands/run.py
+++ b/wa/commands/run.py
@@ -24,7 +24,6 @@ from wa.framework import pluginloader
 from wa.framework.configuration.parsers import AgendaParser
 from wa.framework.execution import Executor
 from wa.framework.output import init_run_output
-from wa.framework.version import get_wa_version
 from wa.framework.exception import NotFoundError, ConfigError
 from wa.utils import log
 from wa.utils.types import toggle_set

--- a/wa/framework/configuration/core.py
+++ b/wa/framework/configuration/core.py
@@ -945,12 +945,9 @@ class JobGenerator(object):
 
     def add_section(self, section, workloads):
         new_node = self.root_node.add_section(section)
-        log.indent()
-        try:
+        with log.indentcontext():
             for workload in workloads:
                 new_node.add_workload(workload)
-        finally:
-            log.dedent()
 
     def add_workload(self, workload):
         self.root_node.add_workload(workload)

--- a/wa/framework/configuration/tree.py
+++ b/wa/framework/configuration/tree.py
@@ -38,12 +38,9 @@ class JobSpecSource(object):
 
     def _log_self(self):
         logger.debug('Creating {} node'.format(self.kind))
-        log.indent()
-        try:
+        with log.indentcontext():
             for key, value in self.config.iteritems():
                 logger.debug('"{}" to "{}"'.format(key, value))
-        finally:
-            log.dedent()
 
 
 class WorkloadEntry(JobSpecSource):

--- a/wa/framework/entrypoint.py
+++ b/wa/framework/entrypoint.py
@@ -26,6 +26,7 @@ from wa.framework.configuration import settings
 from wa.framework.configuration.execution import ConfigManager
 from wa.framework.host import init_user_directory, init_config
 from wa.framework.exception import ConfigError
+from wa.framework.version import get_wa_version
 from wa.utils import log
 from wa.utils.doc import format_body
 
@@ -94,6 +95,8 @@ def main():
         args, _ = parser.parse_known_args(filtered_argv)
         settings.set("verbosity", args.verbose)
         log.init(settings.verbosity)
+        logger.debug('Version: {}'.format(get_wa_version()))
+        logger.debug('Command Line: {}'.format(' '.join(sys.argv)))
 
         # each command will add its own subparser
         commands = load_commands(parser.add_subparsers(dest='command'))

--- a/wa/framework/entrypoint.py
+++ b/wa/framework/entrypoint.py
@@ -80,8 +80,8 @@ def main():
 
         # load_commands will trigger plugin enumeration, and we want logging
         # to be enabled for that, which requires the verbosity setting; however
-        # full argument parse cannot be complted until the commands are loaded; so
-        # parse just the base args for know so we can get verbosity.
+        # full argument parsing cannot be completed until the commands are loaded; so
+        # parse just the base args for now so we can get verbosity.
         argv = split_joined_options(sys.argv[1:])
 
         # 'Parse_known_args' automatically displays the default help and exits

--- a/wa/framework/plugin.py
+++ b/wa/framework/plugin.py
@@ -626,8 +626,7 @@ class PluginLoader(object):
 
     def _discover_in_module(self, module):  # NOQA pylint: disable=too-many-branches
         self.logger.debug('Checking module %s', module.__name__)
-        log.indent()
-        try:
+        with log.indentcontext():
             for obj in vars(module).itervalues():
                 if inspect.isclass(obj):
                     if not issubclass(obj, Plugin):
@@ -647,9 +646,6 @@ class PluginLoader(object):
                             self.logger.warning(e)
                         else:
                             raise e
-        finally:
-            log.dedent()
-            pass
 
     def _add_found_plugin(self, obj):
         """

--- a/wa/framework/plugin.py
+++ b/wa/framework/plugin.py
@@ -631,6 +631,8 @@ class PluginLoader(object):
                 if inspect.isclass(obj):
                     if not issubclass(obj, Plugin):
                         continue
+                    if obj.__module__ != module.__name__:
+                        continue
                     if not obj.kind:
                         message = 'Skipping plugin {} as it does not define a kind'
                         self.logger.debug(message.format(obj.__name__))

--- a/wa/framework/resource.py
+++ b/wa/framework/resource.py
@@ -239,12 +239,9 @@ class ResourceResolver(object):
             self.logger.debug('Loading getter {}'.format(gettercls.name))
             getter = self.loader.get_plugin(name=gettercls.name,
                                             kind="resource_getter")
-            log.indent()
-            try:
+            with log.indentcontext():
                 getter.initialize()
                 getter.register(self)
-            finally:
-                log.dedent()
             self.getters.append(getter)
 
     def register(self, source, priority=SourcePriority.local):

--- a/wa/utils/log.py
+++ b/wa/utils/log.py
@@ -21,6 +21,7 @@ import os
 import string
 import subprocess
 import threading
+from contextlib import contextmanager
 
 import colorama
 
@@ -146,6 +147,15 @@ def indent():
 def dedent():
     global _indent_level
     _indent_level -= 1
+
+
+@contextmanager
+def indentcontext():
+    indent()
+    try:
+        yield
+    finally:
+        dedent()
 
 
 def set_indent_level(level):

--- a/wa/utils/log.py
+++ b/wa/utils/log.py
@@ -225,14 +225,18 @@ class InitHandler(logging.handlers.BufferingHandler):
         super(InitHandler, self).__init__(capacity)
         self.targets = []
 
-    def add_target(self, target):
-        if target not in self.targets:
-            self.targets.append(target)
+    def emit(self, record):
+        record.indent_level = _indent_level
+        super(InitHandler, self).emit(record)
 
     def flush(self):
         for target in self.targets:
             self.flush_to_target(target)
         self.buffer = []
+
+    def add_target(self, target):
+        if target not in self.targets:
+            self.targets.append(target)
 
     def flush_to_target(self, target):
         for record in self.buffer:
@@ -250,7 +254,8 @@ class LineFormatter(logging.Formatter):
         if self.usesTime():
             record.asctime = self.formatTime(record, self.datefmt)
 
-        indent = _indent_width * _indent_level
+        indent_level = getattr(record, 'indent_level', _indent_level)
+        indent = _indent_width * indent_level
         d = record.__dict__
         parts = []
         for line in record.message.split('\n'):


### PR DESCRIPTION
- Buffer early log records before a log file becomes available, so that they are
not lost.
- Add `indentcontext` to remove the need for `try`/`finally` guards for ensuring dedenting.
- Remove superfluous "Skipping..." entries from `pluginloader` logging. 