### PR TITLE
fw/execution: handle error on run initialize

### DIFF
--- a/wa/framework/execution.py
+++ b/wa/framework/execution.py
@@ -352,10 +352,12 @@ class Executor(object):
         self.logger.info('Starting run')
         runner = Runner(context, pm)
         signal.send(signal.RUN_STARTED, self)
-        runner.run()
-        context.finalize()
-        self.execute_postamble(context, output)
-        signal.send(signal.RUN_COMPLETED, self)
+        try:
+            runner.run()
+        finally:
+            context.finalize()
+            self.execute_postamble(context, output)
+            signal.send(signal.RUN_COMPLETED, self)
 
     def execute_postamble(self, context, output):
         self.logger.info('Done.')
@@ -441,9 +443,8 @@ class Runner(object):
         signal.connect(self._warning_signalled_callback, signal.WARNING_LOGGED)
         self.context.start_run()
         self.pm.initialize()
-        log.indent()
-        self.context.initialize_jobs()
-        log.dedent()
+        with log.indentcontext():
+            self.context.initialize_jobs()
         self.context.write_state()
 
     def finalize_run(self):

--- a/wa/utils/misc.py
+++ b/wa/utils/misc.py
@@ -258,7 +258,7 @@ def format_duration(seconds, sep=' ', order=['day', 'hour', 'minute', 'second'])
             continue
         suffix = '' if value == 1 else 's'
         result.append('{} {}{}'.format(value, item, suffix))
-    return sep.join(result)
+    return result and sep.join(result) or 'N/A'
 
 
 def get_article(word):


### PR DESCRIPTION
- Use indentcontext inside initialize_run to make sure log level
  is dedented on error.
- Ensure Executor postamble always runs, event if runner errors.
- Fix format_duration() to handle sub-second timedeltas.