### PR TITLE
Fix workload aliases.

### DIFF
--- a/wa/__init__.py
+++ b/wa/__init__.py
@@ -11,7 +11,7 @@ from wa.framework.instrument import (Instrument, very_slow, slow, normal, fast,
                                      very_fast)
 from wa.framework.output import RunOutput, discover_wa_outputs
 from wa.framework.output_processor import OutputProcessor
-from wa.framework.plugin import Plugin, Parameter
+from wa.framework.plugin import Plugin, Parameter, Alias
 from wa.framework.resource import (NO_ONE, JarFile, ApkFile, ReventFile, File,
                                    Executable)
 from wa.framework.target.descriptor import (TargetDescriptor, TargetDescription,

--- a/wa/framework/plugin.py
+++ b/wa/framework/plugin.py
@@ -543,7 +543,7 @@ class PluginLoader(object):
             return (alias_name, {})
         if alias_name in self.aliases:
             alias = self.aliases[alias_name]
-            return (alias.plugin_name, alias.params)
+            return (alias.plugin_name, copy(alias.params))
         raise NotFoundError('Could not find plugin or alias "{}"'.format(alias_name))
 
     # Internal methods.


### PR DESCRIPTION
Workload aliases were broken at some point. When creating job specs, the
defaults for a plugin are set by the plugin_cache. This ensures that the
complete configuration is present in the meta data. This is happening
before the plugin alias is resolved on creation, and so the alias's defaults
were being overwritten by the unaliased plugin defaults in the job spec.

To avoid this, set the correct  defaults when creating the job spec.