### PR TITLE
doc/requirements: Force sphinx to be an older version.

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,1 +1,2 @@
 nose
+sphinx==1.6.5


### PR DESCRIPTION
Readthedocs has updated their default sphinx version to be
incompatible with how our api is generated so force read the docs to use
the latest known working version (1.6.5)