### PR TITLE
Add support for Python 3

### DIFF
--- a/doc/source/changes.rst
+++ b/doc/source/changes.rst
@@ -19,8 +19,8 @@ For more information on migrating from WA2 to WA3 please see the
 
 Not all of WA2 extensions have been ported for the initial 3.0.0 release. We
 have ported the ones we believe to be most widely used and useful. The porting
-work will continue, and more of WA2's extensions will be in the future releases,
-however we do not intend to port absolutely everything, as some things we
+work will continue, and more of WA2's extensions will be in the future releases.
+However, we do not intend to port absolutely everything, as some things we
 believe to be no longer useful.
 
 .. note:: If there a particular WA2 extension you would like to see in WA3 that
@@ -30,6 +30,15 @@ believe to be no longer useful.
 
 New Features
 ~~~~~~~~~~~~
+
+- Python 3 support. WA now runs on both Python 2 and Python 3.
+
+  .. warning:: Python 2 support should now be considered depricated. Python 2
+               will still be fully supported up to the next major release
+               (v3.1). After that, Python 2 will be supported for existing
+               functionality, however there will be no guarantee that newly
+               added functionality would be compatible with Python 2. Support
+               for Python 2 will be dropped completely after release v3.2.
 
 - There is a new Output API which can be used to aid in post processing a
   run's output. For more information please see :ref:`output_processing_api`.

--- a/setup.py
+++ b/setup.py
@@ -81,9 +81,10 @@ params = dict(
         'pyYAML',  # YAML-formatted agenda parsing
         'requests',  # Fetch assets over HTTP
         'devlib>=0.0.4',  # Interacting with devices
-        'louie',  # callbacks dispatch
+        'louie-latest',  # callbacks dispatch
         'wrapt',  # better decorators
         'pandas>=0.13.1',  # Data analysis and manipulation
+        'future',  # Python 2-3 compatiblity
     ],
     dependency_links=['https://github.com/ARM-software/devlib/tarball/master#egg=devlib-0.0.4'],
 
@@ -104,7 +105,7 @@ params = dict(
     ],
 )
 
-all_extras = list(chain(params['extras_require'].itervalues()))
+all_extras = list(chain(iter(params['extras_require'].values())))
 params['extras_require']['everything'] = all_extras
 
 setup(**params)

--- a/wa/commands/create.py
+++ b/wa/commands/create.py
@@ -94,9 +94,9 @@ class CreateWorkloadSubcommand(SubCommand):
         self.parser.add_argument('-f', '--force', action='store_true',
                                  help='Create the new workload even if a workload with the specified ' +
                                       'name already exists.')
-        self.parser.add_argument('-k', '--kind', metavar='KIND', default='basic', choices=create_funcs.keys(),
+        self.parser.add_argument('-k', '--kind', metavar='KIND', default='basic', choices=list(create_funcs.keys()),
                                  help='The type of workload to be created. The available options ' +
-                                      'are: {}'.format(', '.join(create_funcs.keys())))
+                                      'are: {}'.format(', '.join(list(create_funcs.keys()))))
 
     def execute(self, state, args):  # pylint: disable=R0201
         where = args.path or 'local'
@@ -179,7 +179,7 @@ def create_workload(name, kind='basic', where='local', check_name=True, **kwargs
     except KeyError:
         raise CommandError('Unknown workload type: {}'.format(kind))
 
-    print 'Workload created in {}'.format(workload_dir)
+    print('Workload created in {}'.format(workload_dir))
 
 
 def create_template_workload(path, name, kind, class_name):

--- a/wa/commands/list.py
+++ b/wa/commands/list.py
@@ -71,7 +71,7 @@ def list_targets():
     output = DescriptionListFormatter()
     for target in targets:
         output.add_item(target.description or '', target.name)
-    print output.format_data()
+    print(output.format_data())
 
 
 def list_plugins(args, filters):
@@ -80,7 +80,7 @@ def list_plugins(args, filters):
         filtered_results = []
         for result in results:
             passed = True
-            for k, v in filters.iteritems():
+            for k, v in filters.items():
                 if getattr(result, k) != v:
                     passed = False
                     break
@@ -95,7 +95,7 @@ def list_plugins(args, filters):
         output = DescriptionListFormatter()
         for result in sorted(filtered_results, key=lambda x: x.name):
             output.add_item(get_summary(result), result.name)
-        print output.format_data()
+        print(output.format_data())
 
 
 def check_platform(plugin, platform):

--- a/wa/commands/revent.py
+++ b/wa/commands/revent.py
@@ -24,6 +24,10 @@ from wa.framework.target.manager import TargetManager
 from wa.utils.revent import ReventRecorder
 
 
+if sys.version_info[0] == 3:
+    raw_input = input
+
+
 class RecordCommand(Command):
 
     name = 'record'
@@ -146,7 +150,7 @@ class RecordCommand(Command):
         if os.path.exists(host_path):
             msg = 'Revent file \'{}\' already exists, overwrite? [y/n]'
             self.logger.info(msg.format(revent_file_name))
-            if raw_input('') == 'y':
+            if input('') == 'y':
                 os.remove(host_path)
             else:
                 msg = 'Did not pull and overwrite \'{}\''
@@ -222,7 +226,7 @@ class RecordCommand(Command):
         if not file_name:
             file_name = '{}.revent'.format(self.target.model)
         if not output_path:
-            output_path = os.getcwdu()
+            output_path = os.getcwd()
 
         return output_path, file_name
 

--- a/wa/commands/show.py
+++ b/wa/commands/show.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import sys
 from subprocess import call, Popen, PIPE
 
 from wa import Command
@@ -66,7 +67,11 @@ class ShowCommand(Command):
 
         if which('pandoc'):
             p = Popen(['pandoc', '-f', 'rst', '-t', 'man'], stdin=PIPE, stdout=PIPE, stderr=PIPE)
-            output, _ = p.communicate(rst_output)
+            if sys.version_info[0] == 3:
+                output, _ = p.communicate(rst_output.encode(sys.stdin.encoding))
+                output = output.decode(sys.stdout.encoding)
+            else:
+                output, _ = p.communicate(rst_output)
 
             # Make sure to double escape back slashes
             output = output.replace('\\', '\\\\\\')
@@ -78,7 +83,7 @@ class ShowCommand(Command):
 
             call('echo "{}" | man -l -'.format(escape_double_quotes(output)), shell=True)
         else:
-            print rst_output
+            print(rst_output)
 
 
 def get_target_description(name):

--- a/wa/framework/configuration/core.py
+++ b/wa/framework/configuration/core.py
@@ -95,11 +95,11 @@ class RebootPolicy(object):
 
     __repr__ = __str__
 
-    def __cmp__(self, other):
+    def __eq__(self, other):
         if isinstance(other, RebootPolicy):
-            return cmp(self.policy, other.policy)
+            return self.policy == other.policy
         else:
-            return cmp(self.policy, other)
+            return self.policy == other
 
     def to_pod(self):
         return self.policy
@@ -127,7 +127,7 @@ class LoggingConfig(dict):
     def __init__(self, config=None):
         dict.__init__(self)
         if isinstance(config, dict):
-            config = {identifier(k.lower()): v for k, v in config.iteritems()}
+            config = {identifier(k.lower()): v for k, v in config.items()}
             self['regular_format'] = config.pop('regular_format', self.defaults['regular_format'])
             self['verbose_format'] = config.pop('verbose_format', self.defaults['verbose_format'])
             self['file_format'] = config.pop('file_format', self.defaults['file_format'])
@@ -135,9 +135,9 @@ class LoggingConfig(dict):
             self['color'] = config.pop('color', self.defaults['color'])
             if config:
                 message = 'Unexpected logging configuration parameters: {}'
-                raise ValueError(message.format(bad_vals=', '.join(config.keys())))
+                raise ValueError(message.format(bad_vals=', '.join(list(config.keys()))))
         elif config is None:
-            for k, v in self.defaults.iteritems():
+            for k, v in self.defaults.items():
                 self[k] = v
         else:
             raise ValueError(config)
@@ -360,7 +360,7 @@ class Configuration(object):
                 cfg_point.set_value(instance, value)
         if pod:
             msg = 'Invalid entry(ies) for "{}": "{}"'
-            raise ValueError(msg.format(cls.name, '", "'.join(pod.keys())))
+            raise ValueError(msg.format(cls.name, '", "'.join(list(pod.keys()))))
         return instance
 
     def __init__(self):
@@ -380,7 +380,7 @@ class Configuration(object):
 
 
     def update_config(self, values, check_mandatory=True):
-        for k, v in values.iteritems():
+        for k, v in values.items():
             self.set(k, v, check_mandatory=check_mandatory)
 
     def validate(self):
@@ -824,7 +824,7 @@ class JobSpec(Configuration):
     def update_config(self, source, check_mandatory=True):
         self._sources.append(source)
         values = source.config
-        for k, v in values.iteritems():
+        for k, v in values.items():
             if k == "id":
                 continue
             elif k.endswith('_parameters'):
@@ -849,7 +849,7 @@ class JobSpec(Configuration):
             if not config:
                 continue
 
-            for name, cfg_point in cfg_points.iteritems():
+            for name, cfg_point in cfg_points.items():
                 if name in config:
                     value = config.pop(name)
                     cfg_point.set_value(workload_params, value,
@@ -873,7 +873,7 @@ class JobSpec(Configuration):
                 runtime_parameters[source] = global_runtime_params[source]
 
         # Add runtime parameters from JobSpec
-        for source, values in self.to_merge['runtime_parameters'].iteritems():
+        for source, values in self.to_merge['runtime_parameters'].items():
             runtime_parameters[source] = values
 
         # Merge
@@ -884,9 +884,9 @@ class JobSpec(Configuration):
                             for source in self._sources[1:]])  # ignore first id, "global"
 
         # ensure *_parameters are always obj_dict's
-        self.boot_parameters = obj_dict((self.boot_parameters or {}).items())
-        self.runtime_parameters = obj_dict((self.runtime_parameters or {}).items())
-        self.workload_parameters = obj_dict((self.workload_parameters or {}).items())
+        self.boot_parameters = obj_dict(list((self.boot_parameters or {}).items()))
+        self.runtime_parameters = obj_dict(list((self.runtime_parameters or {}).items()))
+        self.workload_parameters = obj_dict(list((self.workload_parameters or {}).items()))
 
         if self.label is None:
             self.label = self.workload_name
@@ -903,7 +903,7 @@ class JobGenerator(object):
         self._read_augmentations = True
         if self._enabled_instruments is None:
             self._enabled_instruments = []
-            for entry in self._enabled_augmentations.merge_with(self.disabled_augmentations).values():
+            for entry in list(self._enabled_augmentations.merge_with(self.disabled_augmentations).values()):
                 entry_cls = self.plugin_cache.get_plugin_class(entry)
                 if entry_cls.kind == 'instrument':
                     self._enabled_instruments.append(entry)
@@ -914,7 +914,7 @@ class JobGenerator(object):
         self._read_augmentations = True
         if self._enabled_processors is None:
             self._enabled_processors = []
-            for entry in self._enabled_augmentations.merge_with(self.disabled_augmentations).values():
+            for entry in list(self._enabled_augmentations.merge_with(self.disabled_augmentations).values()):
                 entry_cls = self.plugin_cache.get_plugin_class(entry)
                 if entry_cls.kind == 'output_processor':
                     self._enabled_processors.append(entry)
@@ -934,7 +934,7 @@ class JobGenerator(object):
         self.job_spec_template.name = "globally specified job spec configuration"
         self.job_spec_template.id = "global"
         # Load defaults
-        for cfg_point in JobSpec.configuration.itervalues():
+        for cfg_point in JobSpec.configuration.values():
             cfg_point.set_value(self.job_spec_template, check_mandatory=False)
 
         self.root_node = SectionNode(self.job_spec_template)
@@ -996,7 +996,7 @@ class JobGenerator(object):
                             break
                     else:
                         continue
-                self.update_augmentations(job_spec.augmentations.values())
+                self.update_augmentations(list(job_spec.augmentations.values()))
                 specs.append(job_spec)
         return specs
 

--- a/wa/framework/configuration/execution.py
+++ b/wa/framework/configuration/execution.py
@@ -1,5 +1,7 @@
 import random
-from itertools import izip_longest, groupby, chain
+from itertools import groupby, chain
+
+from future.moves.itertools import zip_longest
 
 from wa.framework.configuration.core import (MetaConfiguration, RunConfiguration,
                                              JobGenerator, Status, settings)
@@ -157,8 +159,8 @@ def permute_by_iteration(specs):
     all_tuples = []
     for spec in chain(*groups):
         all_tuples.append([(spec, i + 1)
-                           for i in xrange(spec.iterations)])
-    for t in chain(*map(list, izip_longest(*all_tuples))):
+                           for i in range(spec.iterations)])
+    for t in chain(*list(map(list, zip_longest(*all_tuples)))):
         if t is not None:
             yield t
 
@@ -183,8 +185,8 @@ def permute_by_section(specs):
     all_tuples = []
     for spec in chain(*groups):
         all_tuples.append([(spec, i + 1)
-                           for i in xrange(spec.iterations)])
-    for t in chain(*map(list, izip_longest(*all_tuples))):
+                           for i in range(spec.iterations)])
+    for t in chain(*list(map(list, zip_longest(*all_tuples)))):
         if t is not None:
             yield t
 
@@ -196,7 +198,7 @@ def permute_randomly(specs):
     """
     result = []
     for spec in specs:
-        for i in xrange(1, spec.iterations + 1):
+        for i in range(1, spec.iterations + 1):
             result.append((spec, i))
     random.shuffle(result)
     for t in result:
@@ -214,5 +216,5 @@ permute_map = {
 def permute_iterations(specs, exec_order):
     if exec_order not in permute_map:
         msg = 'Unknown execution order "{}"; must be in: {}'
-        raise ValueError(msg.format(exec_order, permute_map.keys()))
+        raise ValueError(msg.format(exec_order, list(permute_map.keys())))
     return permute_map[exec_order](specs)

--- a/wa/framework/configuration/parsers.py
+++ b/wa/framework/configuration/parsers.py
@@ -21,6 +21,7 @@ from wa.framework.exception import ConfigError
 from wa.utils import log
 from wa.utils.serializer import json, read_pod, SerializerSyntaxError
 from wa.utils.types import toggle_set, counter
+from functools import reduce
 
 
 logger = logging.getLogger('config')
@@ -47,27 +48,27 @@ class ConfigParser(object):
             merge_augmentations(raw)
 
             # Get WA core configuration
-            for cfg_point in state.settings.configuration.itervalues():
+            for cfg_point in state.settings.configuration.values():
                 value = pop_aliased_param(cfg_point, raw)
                 if value is not None:
                     logger.debug('Setting meta "{}" to "{}"'.format(cfg_point.name, value))
                     state.settings.set(cfg_point.name, value)
 
             # Get run specific configuration
-            for cfg_point in state.run_config.configuration.itervalues():
+            for cfg_point in state.run_config.configuration.values():
                 value = pop_aliased_param(cfg_point, raw)
                 if value is not None:
                     logger.debug('Setting run "{}" to "{}"'.format(cfg_point.name, value))
                     state.run_config.set(cfg_point.name, value)
 
             # Get global job spec configuration
-            for cfg_point in JobSpec.configuration.itervalues():
+            for cfg_point in JobSpec.configuration.values():
                 value = pop_aliased_param(cfg_point, raw)
                 if value is not None:
                     logger.debug('Setting global "{}" to "{}"'.format(cfg_point.name, value))
                     state.jobs_config.set_global_value(cfg_point.name, value)
 
-            for name, values in raw.iteritems():
+            for name, values in raw.items():
                 # Assume that all leftover config is for a plug-in or a global
                 # alias it is up to PluginCache to assert this assumption
                 logger.debug('Caching "{}" with "{}"'.format(name, values))
@@ -106,7 +107,7 @@ class AgendaParser(object):
 
             if raw:
                 msg = 'Invalid top level agenda entry(ies): "{}"'
-                raise ConfigError(msg.format('", "'.join(raw.keys())))
+                raise ConfigError(msg.format('", "'.join(list(raw.keys()))))
 
             sect_ids, wkl_ids = self._collect_ids(sections, global_workloads)
             self._process_global_workloads(state, global_workloads, wkl_ids)
@@ -298,7 +299,7 @@ def _construct_valid_entry(raw, seen_ids, prefix, jobs_config):
     merge_augmentations(raw)
 
     # Validate all workload_entry
-    for name, cfg_point in JobSpec.configuration.iteritems():
+    for name, cfg_point in JobSpec.configuration.items():
         value = pop_aliased_param(cfg_point, raw)
         if value is not None:
             value = cfg_point.kind(value)
@@ -314,7 +315,7 @@ def _construct_valid_entry(raw, seen_ids, prefix, jobs_config):
     # error if there are unknown workload_entry
     if raw:
         msg = 'Invalid entry(ies) in "{}": "{}"'
-        raise ConfigError(msg.format(workload_entry['id'], ', '.join(raw.keys())))
+        raise ConfigError(msg.format(workload_entry['id'], ', '.join(list(raw.keys()))))
 
     return workload_entry
 
@@ -336,7 +337,7 @@ def _collect_valid_id(entry_id, seen_ids, entry_type):
 
 
 def _get_workload_entry(workload):
-    if isinstance(workload, basestring):
+    if isinstance(workload, str):
         workload = {'name': workload}
     elif not isinstance(workload, dict):
         raise ConfigError('Invalid workload entry: "{}"')

--- a/wa/framework/configuration/plugin_cache.py
+++ b/wa/framework/configuration/plugin_cache.py
@@ -90,11 +90,11 @@ class PluginCache(object):
             msg = 'configuration provided for unknown plugin "{}"'
             raise ConfigError(msg.format(plugin_name))
 
-        if not hasattr(values, 'iteritems'):
+        if not hasattr(values, 'items'):
             msg = 'Plugin configuration for "{}" not a dictionary ({} is {})'
             raise ConfigError(msg.format(plugin_name, repr(values), type(values)))
 
-        for name, value in values.iteritems():
+        for name, value in values.items():
             if (plugin_name not in GENERIC_CONFIGS and
                     name not in self.get_plugin_parameters(plugin_name)):
                 msg = "'{}' is not a valid parameter for '{}'"
@@ -124,7 +124,7 @@ class PluginCache(object):
             for source in self.sources:
                 if source not in plugin_config:
                     continue
-                for name, value in plugin_config[source].iteritems():
+                for name, value in plugin_config[source].items():
                     cfg_points[name].set_value(config, value=value)
         else:
             # A more complicated merge that involves priority of sources and
@@ -136,7 +136,7 @@ class PluginCache(object):
 
     def get_plugin(self, name, kind=None, *args, **kwargs):
         config = self.get_plugin_config(name)
-        kwargs = dict(config.items() + kwargs.items())
+        kwargs = dict(list(config.items()) + list(kwargs.items()))
         return self.loader.get_plugin(name, kind=kind, *args, **kwargs)
 
     def get_plugin_class(self, name, kind=None):
@@ -154,18 +154,18 @@ class PluginCache(object):
 
     def _set_plugin_defaults(self, plugin_name, config):
         cfg_points = self.get_plugin_parameters(plugin_name)
-        for cfg_point in cfg_points.itervalues():
+        for cfg_point in cfg_points.values():
             cfg_point.set_value(config, check_mandatory=False)
 
         try:
             _, alias_params = self.resolve_alias(plugin_name)
-            for name, value in alias_params.iteritems():
+            for name, value in alias_params.items():
                 cfg_points[name].set_value(config, value)
         except NotFoundError:
             pass
 
     def _set_from_global_aliases(self, plugin_name, config):
-        for alias, param in self._global_alias_map[plugin_name].iteritems():
+        for alias, param in self._global_alias_map[plugin_name].items():
             if alias in self.global_alias_values:
                 for source in self.sources:
                     if source not in self.global_alias_values[alias]:
@@ -230,7 +230,7 @@ class PluginCache(object):
 
         # Validate final configuration
         merged_config.name = specific_name
-        for cfg_point in ms.cfg_points.itervalues():
+        for cfg_point in ms.cfg_points.values():
             cfg_point.validate(merged_config, check_mandatory=is_final)
 
     def __getattr__(self, name):
@@ -285,7 +285,7 @@ class MergeState(object):
 def update_config_from_source(final_config, source, state):
     if source in state.generic_config:
         final_config.name = state.generic_name
-        for name, cfg_point in state.cfg_points.iteritems():
+        for name, cfg_point in state.cfg_points.items():
             if name in state.generic_config[source]:
                 if name in state.seen_specific_config:
                     msg = ('"{generic_name}" configuration "{config_name}" has '
@@ -307,7 +307,7 @@ def update_config_from_source(final_config, source, state):
 
     if source in state.specific_config:
         final_config.name = state.specific_name
-        for name, cfg_point in state.cfg_points.iteritems():
+        for name, cfg_point in state.cfg_points.items():
             if name in state.specific_config[source]:
                 state.seen_specific_config[name].append(str(source))
                 value = state.specific_config[source].pop(name)

--- a/wa/framework/configuration/tree.py
+++ b/wa/framework/configuration/tree.py
@@ -39,7 +39,7 @@ class JobSpecSource(object):
     def _log_self(self):
         logger.debug('Creating {} node'.format(self.kind))
         with log.indentcontext():
-            for key, value in self.config.iteritems():
+            for key, value in self.config.items():
                 logger.debug('"{}" to "{}"'.format(key, value))
 
 

--- a/wa/framework/exception.py
+++ b/wa/framework/exception.py
@@ -20,7 +20,11 @@ from wa.utils.misc import get_traceback
 
 class WAError(Exception):
     """Base class for all Workload Automation exceptions."""
-    pass
+    @property
+    def message(self):
+        if self.args:
+            return self.args[0]
+        return ''
 
 
 class NotFoundError(WAError):

--- a/wa/framework/execution.py
+++ b/wa/framework/execution.py
@@ -464,7 +464,7 @@ class Runner(object):
             self.logger.info('Skipping remaining jobs.')
             self.context.skip_remaining_jobs()
         except Exception as e:
-            message = e.message if e.message else str(e)
+            message = e.args[0] if e.args else str(e)
             log.log_error(e, self.logger)
             self.logger.error('Skipping remaining jobs due to "{}".'.format(e))
             self.context.skip_remaining_jobs()

--- a/wa/framework/host.py
+++ b/wa/framework/host.py
@@ -90,7 +90,7 @@ def convert_wa2_agenda(filepath, output_path):
                             default=True),
             ])
 
-    for param in orig_agenda.keys():
+    for param in list(orig_agenda.keys()):
         for cfg_point in config_points:
             if param == cfg_point.name or param in cfg_point.aliases:
                 if cfg_point.name == 'augmentations':
@@ -105,7 +105,7 @@ def convert_wa2_agenda(filepath, output_path):
 
         # Convert plugin configuration
         output.write("# Plugin Configuration\n")
-        for param in orig_agenda.keys():
+        for param in list(orig_agenda.keys()):
             if pluginloader.has_plugin(param):
                 entry = {param: orig_agenda.pop(param)}
                 yaml.dump(format_parameter(entry), output, default_flow_style=False)
@@ -114,7 +114,7 @@ def convert_wa2_agenda(filepath, output_path):
         # Write any additional aliased parameters into new config
         plugin_cache = PluginCache()
         output.write("# Additional global aliases\n")
-        for param in orig_agenda.keys():
+        for param in list(orig_agenda.keys()):
             if plugin_cache.is_global_alias(param):
                 entry = {param: orig_agenda.pop(param)}
                 yaml.dump(format_parameter(entry), output, default_flow_style=False)
@@ -123,7 +123,7 @@ def convert_wa2_agenda(filepath, output_path):
 
 def format_parameter(param):
     if isinstance(param, dict):
-         return {identifier(k) : v for k, v in param.iteritems()}
+         return {identifier(k) : v for k, v in param.items()}
     else:
         return param
 

--- a/wa/framework/instrument.py
+++ b/wa/framework/instrument.py
@@ -165,7 +165,7 @@ def priority(priority):
     def decorate(func):
         def wrapper(*args, **kwargs):
             return func(*args, **kwargs)
-        wrapper.func_name = func.func_name
+        wrapper.__name__ = func.__name__
         if priority in signal.CallbackPriority.levels:
             wrapper.priority = signal.CallbackPriority(priority)
         else:
@@ -255,7 +255,7 @@ class ManagedCallback(object):
                 global failures_detected  # pylint: disable=W0603
                 failures_detected = True
                 log_error(e, logger)
-                context.add_event(e.message)
+                context.add_event(e.args[0] if e.args else str(e))
                 if isinstance(e, WorkloadError):
                     context.set_status('FAILED')
                 elif isinstance(e, TargetError) or isinstance(e, TimeoutError):
@@ -268,7 +268,7 @@ class ManagedCallback(object):
 
     def __repr__(self):
         text = 'ManagedCallback({}, {})'
-        return text.format(self.instrument.name, self.callback.im_func.func_name)
+        return text.format(self.instrument.name, self.callback.__func__.__name__)
 
     __str__ = __repr__
 

--- a/wa/framework/job.py
+++ b/wa/framework/job.py
@@ -85,7 +85,7 @@ class Job(object):
             enabled_instruments = set(i.name for i in instrument.get_enabled())
             enabled_output_processors = set(p.name for p in pm.get_enabled())
 
-            for augmentation in self.spec.augmentations.values():
+            for augmentation in list(self.spec.augmentations.values()):
                 augmentation_cls = context.cm.plugin_cache.get_plugin_class(augmentation)
                 if augmentation_cls.kind == 'instrument':
                     instruments_to_enable.add(augmentation)

--- a/wa/framework/output.py
+++ b/wa/framework/output.py
@@ -10,7 +10,7 @@ from wa.framework.configuration.execution import CombinedConfig
 from wa.framework.exception import HostError
 from wa.framework.run import RunState, RunInfo
 from wa.framework.target.info import TargetInfo
-from wa.utils.misc import touch, ensure_directory_exists
+from wa.utils.misc import touch, ensure_directory_exists, isiterable
 from wa.utils.serializer import write_pod, read_pod, is_pod
 from wa.utils.types import enum, numeric
 
@@ -229,7 +229,7 @@ class RunOutput(Output):
         if os.path.isfile(self.jobsfile):
             self.job_specs = self.read_job_specs()
 
-        for job_state in self.state.jobs.itervalues():
+        for job_state in self.state.jobs.values():
             job_path = os.path.join(self.basepath, job_state.output_name)
             job = JobOutput(job_path, job_state.id,
                             job_state.label, job_state.iteration,
@@ -387,14 +387,14 @@ class Result(object):
         if key not in self.metadata:
             return self.add_metadata(key, *args)
 
-        if hasattr(self.metadata[key], 'iteritems'):
+        if hasattr(self.metadata[key], 'items'):
             if len(args) == 2:
                 self.metadata[key][args[0]] = args[1]
             elif len(args) > 2:  # assume list of key-value pairs
                 for k, v in args:
                     self.metadata[key][k] = v
-            elif hasattr(args[0], 'iteritems'):
-                for k, v in args[0].iteritems():
+            elif hasattr(args[0], 'items'):
+                for k, v in args[0].items():
                     self.metadata[key][k] = v
             else:
                 raise ValueError('Invalid value for key "{}": {}'.format(key, args))

--- a/wa/framework/pluginloader.py
+++ b/wa/framework/pluginloader.py
@@ -21,7 +21,7 @@ class __LoaderWrapper(object):
     def kinds(self):
         if not self._loader:
             self.reset()
-        return self._loader.kind_map.keys()
+        return list(self._loader.kind_map.keys())
 
     @property
     def kind_map(self):

--- a/wa/framework/resource.py
+++ b/wa/framework/resource.py
@@ -287,7 +287,7 @@ def loose_version_matching(config_version, apk_version):
     if len(apk_version) < len(config_version):
         return False  # More specific version requested than available
 
-    for i in xrange(len(config_version)):
+    for i in range(len(config_version)):
         if config_version[i] != apk_version[i]:
             return False
     return True

--- a/wa/framework/run.py
+++ b/wa/framework/run.py
@@ -76,7 +76,7 @@ class RunState(object):
 
     @property
     def num_completed_jobs(self):
-        return sum(1 for js in self.jobs.itervalues()
+        return sum(1 for js in self.jobs.values()
                    if js.status > Status.RUNNING)
 
     def __init__(self):
@@ -95,7 +95,7 @@ class RunState(object):
 
     def get_status_counts(self):
         counter = Counter()
-        for job_state in self.jobs.itervalues():
+        for job_state in self.jobs.values():
             counter[job_state.status] += 1
         return counter
 
@@ -103,7 +103,7 @@ class RunState(object):
         return OrderedDict(
             status=str(self.status),
             timestamp=self.timestamp,
-            jobs=[j.to_pod() for j in self.jobs.itervalues()],
+            jobs=[j.to_pod() for j in self.jobs.values()],
         )
 
 

--- a/wa/framework/target/descriptor.py
+++ b/wa/framework/target/descriptor.py
@@ -28,7 +28,7 @@ def list_target_descriptions(loader=pluginloader):
                 raise PluginLoaderError(msg.format(desc.name, prev_dtor.name,
                                                    descriptor.name))
             targets[desc.name] = desc
-    return targets.values()
+    return list(targets.values())
 
 
 def get_target_description(name, loader=pluginloader):
@@ -47,11 +47,11 @@ def instantiate_target(tdesc, params, connect=None, extra_platform_params=None):
     tp, pp, cp = {}, {}, {}
 
     for supported_params, new_params in (target_params, tp), (platform_params, pp), (conn_params, cp):
-        for name, value in supported_params.iteritems():
+        for name, value in supported_params.items():
             if value.default and name == value.name:
                 new_params[name] = value.default
 
-    for name, value in params.iteritems():
+    for name, value in params.items():
         if name in target_params:
             tp[name] = value
         elif name in platform_params:
@@ -64,7 +64,7 @@ def instantiate_target(tdesc, params, connect=None, extra_platform_params=None):
             msg = 'Unexpected parameter for {}: {}'
             raise ValueError(msg.format(tdesc.name, name))
 
-    for pname, pval in (extra_platform_params or {}).iteritems():
+    for pname, pval in (extra_platform_params or {}).items():
         if pname in pp:
             raise RuntimeError('Platform parameter clash: {}'.format(pname))
         pp[pname] = pval
@@ -121,7 +121,7 @@ class TargetDescription(object):
             vals = []
         elif isiterable(vals):
             if hasattr(vals, 'values'):
-                vals = v.values()
+                vals = list(v.values())
         else:
             msg = '{} must be iterable; got "{}"'
             raise ValueError(msg.format(attr, vals))
@@ -453,11 +453,11 @@ class DefaultTargetDescriptor(TargetDescriptor):
 
     def get_descriptions(self):
         result = []
-        for target_name, target_tuple in TARGETS.iteritems():
+        for target_name, target_tuple in TARGETS.items():
             (target, conn), target_params = self._get_item(target_tuple)
             assistant = ASSISTANTS[target_name]
             conn_params =  CONNECTION_PARAMS[conn]
-            for platform_name, platform_tuple in PLATFORMS.iteritems():
+            for platform_name, platform_tuple in PLATFORMS.items():
                 (platform, plat_conn), platform_params = self._get_item(platform_tuple)
                 name = '{}_{}'.format(platform_name, target_name)
                 td = TargetDescription(name, self)
@@ -484,11 +484,11 @@ class DefaultTargetDescriptor(TargetDescriptor):
             return cls, params
 
         param_map = OrderedDict((p.name, copy(p)) for p in params)
-        for name, value in defaults.iteritems():
+        for name, value in defaults.items():
             if name not in param_map:
                 raise ValueError('Unexpected default "{}"'.format(name))
             param_map[name].default = value
-        return cls, param_map.values()
+        return cls, list(param_map.values())
 
 
 
@@ -522,7 +522,7 @@ def create_target_description(name, *args, **kwargs):
 def _get_target_defaults(target):
     specificity = 0
     res = ('linux', TARGETS['linux'])  # fallback to a generic linux target
-    for name, ttup in TARGETS.iteritems():
+    for name, ttup in TARGETS.items():
         if issubclass(target, ttup[0][0]):
             new_spec =  len(inspect.getmro(ttup[0][0]))
             if new_spec > specificity:
@@ -540,7 +540,7 @@ def add_description_for_target(target, description=None, **kwargs):
     if 'platform' not in kwargs:
         kwargs['platform'] = Platform
     if 'platform_params' not in kwargs:
-        for (plat, conn), params, _ in PLATFORMS.itervalues():
+        for (plat, conn), params, _ in PLATFORMS.values():
             if plat == kwargs['platform']:
                 kwargs['platform_params'] = params
                 if conn is not None and kwargs['conn'] is None:

--- a/wa/framework/target/info.py
+++ b/wa/framework/target/info.py
@@ -10,7 +10,7 @@ def cpuinfo_from_pod(pod):
     cpuinfo.sections = pod['cpuinfo']
     lines = []
     for section in cpuinfo.sections:
-        for key, value in section.iteritems():
+        for key, value in section.items():
             line = '{}: {}'.format(key, value)
             lines.append(line)
         lines.append('')
@@ -35,7 +35,7 @@ def kernel_config_from_pod(pod):
     config = KernelConfig('')
     config._config = pod['kernel_config']
     lines = []
-    for key, value in config._config.iteritems():
+    for key, value in config._config.items():
         if value == 'n':
             lines.append('# {} is not set'.format(key))
         else:

--- a/wa/framework/target/runtime_config.py
+++ b/wa/framework/target/runtime_config.py
@@ -33,7 +33,7 @@ class RuntimeConfig(Plugin):
 
     @property
     def supported_parameters(self):
-        return self._runtime_params.values()
+        return list(self._runtime_params.values())
 
     @property
     def core_names(self):
@@ -166,12 +166,12 @@ class HotplugRuntimeConfig(RuntimeConfig):
 
     def validate_parameters(self):
         if len(self.num_cores) == self.target.number_of_cpus:
-            if all(v is False for v in self.num_cores.values()):
+            if all(v is False for v in list(self.num_cores.values())):
                 raise ValueError('Cannot set number of all cores to 0')
 
     def commit(self):
         '''Online all CPUs required in order before then off-lining'''
-        num_cores = sorted(self.num_cores.iteritems())
+        num_cores = sorted(self.num_cores.items())
         for cpu, online in num_cores:
             if online:
                 self.target.hotplug.online(cpu)
@@ -190,7 +190,7 @@ class SysfileValuesRuntimeConfig(RuntimeConfig):
     #pylint: disable=unused-argument
     @staticmethod
     def set_sysfile(obj, value, core):
-        for path, value in value.iteritems():
+        for path, value in value.items():
             verify = True
             if path.endswith('!'):
                 verify = False
@@ -222,7 +222,7 @@ class SysfileValuesRuntimeConfig(RuntimeConfig):
         return
 
     def commit(self):
-        for path, (value, verify) in self.sysfile_values.iteritems():
+        for path, (value, verify) in self.sysfile_values.items():
             self.target.write_value(path, value, verify=verify)
 
     def clear(self):
@@ -255,7 +255,7 @@ class FreqValue(object):
                 raise TargetError(msg.format(value))
         elif isinstance(value, int) and value in self.values:
             return value
-        elif isinstance(value, basestring):
+        elif isinstance(value, str):
             value = caseless_string(value)
             if value in ['min', 'max']:
                 return value
@@ -675,7 +675,7 @@ class IdleStateValue(object):
         if self.values is None:
             return value
 
-        if isinstance(value, basestring):
+        if isinstance(value, str):
             value = caseless_string(value)
             if value == 'all':
                 return [state[0] for state in self.values]

--- a/wa/framework/target/runtime_parameter_manager.py
+++ b/wa/framework/target/runtime_parameter_manager.py
@@ -39,7 +39,7 @@ class RuntimeParameterManager(object):
     def merge_runtime_parameters(self, parameters):
         merged_params = obj_dict()
         for source in parameters:
-            for name, value in parameters[source].iteritems():
+            for name, value in parameters[source].items():
                 cp = self.get_cfg_point(name)
                 cp.set_value(merged_params, value)
         return dict(merged_params)
@@ -60,7 +60,7 @@ class RuntimeParameterManager(object):
 
     # Stores a set of parameters performing isolated validation when appropriate
     def set_runtime_parameters(self, parameters):
-        for name, value in parameters.iteritems():
+        for name, value in parameters.items():
             cfg = self.get_config_for_name(name)
             if cfg is None:
                 msg = 'Unsupported runtime parameter: "{}"'
@@ -74,14 +74,14 @@ class RuntimeParameterManager(object):
 
     def get_config_for_name(self, name):
         name = caseless_string(name)
-        for k, v in self.runtime_params.iteritems():
+        for k, v in self.runtime_params.items():
             if name == k:
                 return v.rt_config
         return None
 
     def get_cfg_point(self, name):
         name = caseless_string(name)
-        for k, v in self.runtime_params.iteritems():
+        for k, v in self.runtime_params.items():
             if name == k:
                 return v.cfg_point
         raise ConfigError('Unknown runtime parameter: {}'.format(name))

--- a/wa/framework/version.py
+++ b/wa/framework/version.py
@@ -14,6 +14,7 @@
 #
 
 import os
+import sys
 from collections import namedtuple
 from subprocess import Popen, PIPE
 
@@ -45,4 +46,7 @@ def get_commit():
     p.wait()
     if p.returncode:
         return None
-    return std[:8]
+    if sys.version_info[0] == 3:
+        return std[:8].decode(sys.stdout.encoding)
+    else:
+        return std[:8]

--- a/wa/instruments/dmesg.py
+++ b/wa/instruments/dmesg.py
@@ -31,7 +31,7 @@ class DmesgInstrument(Instrument):
     name = 'dmesg'
 
     parameters = [
-        Parameter('loglevel', kind=int, allowed_values=range(8),
+        Parameter('loglevel', kind=int, allowed_values=list(range(8)),
                   description='Set loglevel for console output.')
     ]
 

--- a/wa/instruments/energy_measurement.py
+++ b/wa/instruments/energy_measurement.py
@@ -15,7 +15,7 @@
 
 
 # pylint: disable=W0613,E1101
-from __future__ import division
+
 from collections import defaultdict
 import os
 import shutil
@@ -413,9 +413,9 @@ class EnergyMeasurement(Instrument):
         self.params = obj_dict()
 
         instrument_parameters = {identifier(k): v
-                                 for k, v in self.instrument_parameters.iteritems()}
+                                 for k, v in self.instrument_parameters.items()}
         supported_params = self.backend.get_parameters()
-        for name, param in supported_params.iteritems():
+        for name, param in supported_params.items():
             value = instrument_parameters.pop(name, None)
             param.set_value(self.params, value)
         if instrument_parameters:
@@ -426,7 +426,7 @@ class EnergyMeasurement(Instrument):
     def initialize(self, context):
         self.instruments = self.backend.get_instruments(self.target, context.run_output.metadir, **self.params)
 
-        for instrument in self.instruments.itervalues():
+        for instrument in self.instruments.values():
             if not (instrument.mode & CONTINUOUS):
                 msg = '{} instrument does not support continuous measurement collection'
                 raise ConfigError(msg.format(self.instrument))
@@ -436,26 +436,26 @@ class EnergyMeasurement(Instrument):
             # Check that the expeccted channels exist.
             # If there are multiple Instruments, they were all constructed with
             # the same channels param, so check them all.
-            for instrument in self.instruments.itervalues():
+            for instrument in self.instruments.values():
                 if not instrument.get_channels(channel):
                     raise ConfigError('No channels found for "{}"'.format(channel))
 
     def setup(self, context):
-        for instrument in self.instruments.itervalues():
+        for instrument in self.instruments.values():
             instrument.reset(sites=self.sites,
                              kinds=self.kinds,
                              channels=self.channels)
 
     def start(self, context):
-        for instrument in self.instruments.itervalues():
+        for instrument in self.instruments.values():
             instrument.start()
 
     def stop(self, context):
-        for instrument in self.instruments.itervalues():
+        for instrument in self.instruments.values():
             instrument.stop()
 
     def update_output(self, context):
-        for device, instrument in self.instruments.iteritems():
+        for device, instrument in self.instruments.items():
             # Append the device key to the filename and artifact name, unless
             # it's None (as it will be for backends with only 1
             # devce/instrument)
@@ -501,7 +501,7 @@ class EnergyMeasurement(Instrument):
         #  the devlib instrument, before we potentially appended a device key to
         #  it)
         if len(self.instruments) > 1:
-            for name, metrics in metrics_by_name.iteritems():
+            for name, metrics in metrics_by_name.items():
                 units = metrics[0].units
                 value = sum(m.value for m in metrics)
                 context.add_metric(name, value, units)

--- a/wa/instruments/hwmon.py
+++ b/wa/instruments/hwmon.py
@@ -58,11 +58,11 @@ class HwmonInstrument(Instrument):
         measurements_before = {m.channel.label: m for m in self.before}
         measurements_after = {m.channel.label: m for m in self.after}
 
-        if measurements_before.keys() != measurements_after.keys():
+        if list(measurements_before.keys()) != list(measurements_after.keys()):
             self.logger.warning(
                 'hwmon before/after measurements returned different entries!')
 
-        for label, measurement_after in measurements_after.iteritems():
+        for label, measurement_after in measurements_after.items():
             if label not in measurements_before:
                 continue # We've already warned about this
             measurement_before = measurements_before[label]

--- a/wa/instruments/trace_cmd.py
+++ b/wa/instruments/trace_cmd.py
@@ -15,7 +15,7 @@
 
 
 # pylint: disable=W0613,E1101
-from __future__ import division
+
 import os
 
 from devlib import FtraceCollector

--- a/wa/output_processors/csvproc.py
+++ b/wa/output_processors/csvproc.py
@@ -1,4 +1,6 @@
-import csv
+import sys
+
+from devlib.utils.csvutil import csvwriter
 
 from wa import OutputProcessor, Parameter
 from wa.framework.exception import ConfigError
@@ -64,7 +66,7 @@ class CsvReportProcessor(OutputProcessor):
             classifiers = set([])
             for out in outputs:
                 for metric in out.metrics:
-                    classifiers.update(metric.classifiers.keys())
+                    classifiers.update(list(metric.classifiers.keys()))
             extra_columns = list(classifiers)
         elif self.extra_columns:
             extra_columns = self.extra_columns
@@ -72,8 +74,7 @@ class CsvReportProcessor(OutputProcessor):
             extra_columns = []
 
         outfile = output.get_path('results.csv')
-        with open(outfile, 'wb') as wfh:
-            writer = csv.writer(wfh)
+        with csvwriter(outfile) as writer:
             writer.writerow(['id', 'workload', 'iteration', 'metric', ] +
                             extra_columns + ['value', 'units'])
 

--- a/wa/output_processors/status.py
+++ b/wa/output_processors/status.py
@@ -49,8 +49,8 @@ class StatusTxtReporter(OutputProcessor):
             txt = '{}/{} iterations completed without error\n'
             wfh.write(txt.format(counter[Status.OK], len(output.jobs)))
             wfh.write('\n')
-            status_lines = [map(str, [o.id, o.label, o.iteration, o.status,
-                                      o.event_summary])
+            status_lines = [list(map(str, [o.id, o.label, o.iteration, o.status,
+                                      o.event_summary]))
                             for o in output.jobs]
             write_table(status_lines, wfh, align='<<>><')
 

--- a/wa/utils/doc.py
+++ b/wa/utils/doc.py
@@ -164,16 +164,16 @@ def format_simple_table(rows, headers=None, align='>', show_borders=True, border
     """Formats a simple table."""
     if not rows:
         return ''
-    rows = [map(str, r) for r in rows]
+    rows = [list(map(str, r)) for r in rows]
     num_cols = len(rows[0])
 
     # cycle specified alignments until we have num_cols of them. This is
     # consitent with how such cases are handled in R, pandas, etc.
     it = cycle(align)
-    align = [it.next() for _ in xrange(num_cols)]
+    align = [next(it) for _ in range(num_cols)]
 
-    cols = zip(*rows)
-    col_widths = [max(map(len, c)) for c in cols]
+    cols = list(zip(*rows))
+    col_widths = [max(list(map(len, c))) for c in cols]
     if headers:
         col_widths = [max(len(h), cw) for h, cw in zip(headers, col_widths)]
     row_format = ' '.join(['{:%s%s}' % (align[i], w) for i, w in enumerate(col_widths)])
@@ -259,12 +259,12 @@ def indent(text, spaces=4):
 
 
 def format_literal(lit):
-    if isinstance(lit, basestring):
+    if isinstance(lit, str):
         return '``\'{}\'``'.format(lit)
     elif hasattr(lit, 'pattern'):  # regex
         return '``r\'{}\'``'.format(lit.pattern)
     elif isinstance(lit, dict):
-        content = indent(',\n'.join("{}: {}".format(key,val) for (key,val) in lit.iteritems()))
+        content = indent(',\n'.join("{}: {}".format(key,val) for (key,val) in lit.items()))
         return '::\n\n{}'.format(indent('{{\n{}\n}}'.format(content)))
     else:
         return '``{}``'.format(lit)
@@ -287,7 +287,7 @@ def get_params_rst(parameters):
             text += indent('\nconstraint: ``{}``\n'.format(get_type_name(param.constraint)))
         if param.default:
             value = param.default
-            if isinstance(value, basestring) and value.startswith(USER_HOME):
+            if isinstance(value, str) and value.startswith(USER_HOME):
                 value = value.replace(USER_HOME, '~')
             text += indent('\ndefault: {}\n'.format(format_literal(value)))
         text += '\n'
@@ -298,7 +298,7 @@ def get_aliases_rst(aliases):
     text = ''
     for alias in aliases:
         param_str = ', '.join(['{}={}'.format(n, format_literal(v))
-                               for n, v in alias.params.iteritems()])
+                               for n, v in alias.params.items()])
         text += '{}\n{}\n\n'.format(alias.name, indent(param_str))
     return text
 

--- a/wa/utils/exec_control.py
+++ b/wa/utils/exec_control.py
@@ -12,7 +12,7 @@ def activate_environment(name):
     #pylint: disable=W0603
     global __active_environment
 
-    if name not in __environments.keys():
+    if name not in list(__environments.keys()):
         init_environment(name)
     __active_environment = name
 
@@ -24,7 +24,7 @@ def init_environment(name):
     :raises: ``ValueError`` if an environment with name ``name``
              already exists.
     """
-    if name in __environments.keys():
+    if name in list(__environments.keys()):
         msg = "Environment {} already exists".format(name)
         raise ValueError(msg)
     __environments[name] = []
@@ -39,7 +39,7 @@ def reset_environment(name=None):
     """
 
     if name is not None:
-        if name not in __environments.keys():
+        if name not in list(__environments.keys()):
             msg = "Environment {} does not exist".format(name)
             raise ValueError(msg)
         __environments[name] = []
@@ -75,7 +75,7 @@ def once_per_class(method):
         if __active_environment is None:
             activate_environment('default')
 
-        func_id = repr(method.func_name) + repr(args[0].__class__)
+        func_id = repr(method.__name__) + repr(args[0].__class__)
 
         if func_id in __environments[__active_environment]:
             return

--- a/wa/utils/log.py
+++ b/wa/utils/log.py
@@ -128,13 +128,13 @@ def disable(logs):
 
 
 def __enable_logger(logger):
-    if isinstance(logger, basestring):
+    if isinstance(logger, str):
         logger = logging.getLogger(logger)
     logger.propagate = True
 
 
 def __disable_logger(logger):
-    if isinstance(logger, basestring):
+    if isinstance(logger, str):
         logger = logging.getLogger(logger)
     logger.propagate = False
 

--- a/wa/utils/revent.py
+++ b/wa/utils/revent.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-from __future__ import division
+
 import os
 import struct
 import signal
@@ -88,7 +88,7 @@ class UinputDeviceInfo(object):
         self.abs_bits = bytearray(parts[3])
         self.num_absinfo = parts[4]
         self.absinfo = [absinfo(*read_struct(fh, absinfo_struct))
-                        for _ in xrange(self.num_absinfo)]
+                        for _ in range(self.num_absinfo)]
 
     def __str__(self):
         return 'UInputInfo({})'.format(self.__dict__)
@@ -145,7 +145,7 @@ class ReventRecording(object):
             if self.stream:
                 events = self._iter_events()
                 try:
-                    first = last = events.next()
+                    first = last = next(events)
                 except StopIteration:
                     self._duration = 0
                 for last in events:
@@ -230,7 +230,7 @@ class ReventRecording(object):
 
     def _read_devices(self, fh):
         num_devices, = read_struct(fh, u32_struct)
-        for _ in xrange(num_devices):
+        for _ in range(num_devices):
             self.device_paths.append(read_string(fh))
 
     def _read_gamepad_info(self, fh):
@@ -243,7 +243,7 @@ class ReventRecording(object):
             raise RuntimeError(msg)
         self.fh.seek(self._events_start)
         if self.version >= 2:
-            for _ in xrange(self.num_events):
+            for _ in range(self.num_events):
                 yield ReventEvent(self.fh)
         else:
             file_size = os.path.getsize(self.filepath)

--- a/wa/utils/terminalsize.py
+++ b/wa/utils/terminalsize.py
@@ -89,5 +89,5 @@ def _get_terminal_size_linux():
 
 if __name__ == "__main__":
     sizex, sizey = get_terminal_size()
-    print 'width =', sizex, 'height =', sizey
+    print('width =', sizex, 'height =', sizey)
 

--- a/wa/utils/trace_cmd.py
+++ b/wa/utils/trace_cmd.py
@@ -114,7 +114,7 @@ class DroppedEventsEvent(object):
 def try_convert_to_numeric(v):
     try:
         if isiterable(v):
-            return map(numeric, v)
+            return list(map(numeric, v))
         else:
             return numeric(v)
     except ValueError:
@@ -153,13 +153,13 @@ def regex_body_parser(regex, flags=0):
     If regex is a pre-compiled object, flags will be ignored.
 
     """
-    if isinstance(regex, basestring):
+    if isinstance(regex, str):
         regex = re.compile(regex, flags)
 
     def regex_parser_func(event, text):
         match = regex.search(text)
         if match:
-            for k, v in match.groupdict().iteritems():
+            for k, v in match.groupdict().items():
                 try:
                     event.fields[k] = int(v)
                 except ValueError:
@@ -321,7 +321,7 @@ class TraceCmdParser(object):
                         continue
 
                 body_parser = EVENT_PARSER_MAP.get(event_name, default_body_parser)
-                if isinstance(body_parser, basestring) or isinstance(body_parser, re._pattern_type):  # pylint: disable=protected-access
+                if isinstance(body_parser, str) or isinstance(body_parser, re._pattern_type):  # pylint: disable=protected-access
                     body_parser = regex_body_parser(body_parser)
                 yield TraceCmdEvent(parser=body_parser, **match.groupdict())
 

--- a/wa/workloads/exoplayer/__init__.py
+++ b/wa/workloads/exoplayer/__init__.py
@@ -18,7 +18,13 @@
 import re
 import os
 import time
-import urllib
+
+from future.standard_library import install_aliases
+install_aliases()
+
+import urllib.request
+import urllib.parse
+import urllib.error
 
 from wa import ApkWorkload, Parameter, ConfigError, WorkloadError
 from wa.framework.configuration.core import settings
@@ -81,7 +87,7 @@ class ExoPlayer(ApkWorkload):
                   Playback duration of the video file. This becomes the duration of the workload.
                   If provided must be shorter than the length of the media.
                   """),
-        Parameter('format', allowed_values=DOWNLOAD_URLS.keys(),
+        Parameter('format', allowed_values=list(DOWNLOAD_URLS.keys()),
                   description="""
                   Specifies which format video file to play. Default is {}
                   """.format(default_format)),
@@ -137,7 +143,7 @@ class ExoPlayer(ApkWorkload):
                 filename = '{}_{}'.format(format_resolution, os.path.basename(url))
                 filepath = os.path.join(self.video_directory, filename)
                 self.logger.info('Downloading {} to {}...'.format(url, filepath))
-                urllib.urlretrieve(url, filepath)
+                urllib.request.urlretrieve(url, filepath)
                 return filepath
             else:
                 if len(files) > 1:
@@ -172,7 +178,7 @@ class ExoPlayer(ApkWorkload):
         self.play_cmd = 'am start -a {} -d "file://{}"'.format(self.action,
                                                                self.device_video_file)
 
-        self.monitor = self.target.get_logcat_monitor(REGEXPS.values())
+        self.monitor = self.target.get_logcat_monitor(list(REGEXPS.values()))
         self.monitor.start()
 
     def run(self, context):

--- a/wa/workloads/hackbench/__init__.py
+++ b/wa/workloads/hackbench/__init__.py
@@ -84,7 +84,7 @@ class Hackbench(Workload):
         results_file = context.get_artifact_path('hackbench-results')
         with open(results_file) as fh:
             for line in fh:
-                for label, (regex, units) in regex_map.iteritems():
+                for label, (regex, units) in regex_map.items():
                     match = regex.search(line)
                     if match:
                         context.add_metric(label, float(match.group(1)), units)

--- a/wa/workloads/jankbench/__init__.py
+++ b/wa/workloads/jankbench/__init__.py
@@ -15,7 +15,7 @@
 
 # pylint: disable=E1101,W0201,E0203
 
-from __future__ import division
+
 import os
 import re
 import select
@@ -23,6 +23,7 @@ import json
 import threading
 import sqlite3
 import subprocess
+import sys
 from copy import copy
 
 import pandas as pd
@@ -143,7 +144,7 @@ class Jankbench(ApkWorkload):
 
             for test_name, rep in results.index:
                 test_results = results.ix[test_name, rep]
-                for metric, value in test_results.iteritems():
+                for metric, value in test_results.items():
                     context.add_metric(metric, value, units=None, lower_is_better=True,
                                        classifiers={'test_name': test_name, 'rep': rep})
 
@@ -222,6 +223,8 @@ class JankbenchRunMonitor(threading.Thread):
                 ready, _, _ = select.select([proc.stdout, proc.stderr], [], [], 2)
                 if ready:
                     line = ready[0].readline()
+                    if sys.version_info[0] == 3:
+                        line = line.decode(sys.stdout.encoding)
                     if self.regex.search(line):
                         self.run_ended.set()
 

--- a/wa/workloads/meabo/__init__.py
+++ b/wa/workloads/meabo/__init__.py
@@ -145,7 +145,7 @@ class Meabo(Workload):
             Controls which phases to run.
             ''',
             constraint=lambda x: all(0 < v <=10 for v in x),
-            default=range(1, 11),
+            default=list(range(1, 11)),
         ),
         Parameter(
             'threads',

--- a/wa/workloads/openssl/__init__.py
+++ b/wa/workloads/openssl/__init__.py
@@ -102,7 +102,7 @@ class Openssl(Workload):
 
             parts =  line.split(':')
             if parts[0] == '+F':  # evp ciphers
-                for bs, value  in zip(BLOCK_SIZES, map(float, parts[3:])):
+                for bs, value  in zip(BLOCK_SIZES, list(map(float, parts[3:]))):
                     value = value / 2**20  # to MB
                     context.add_metric('score', value, 'MB/s',
                                        classifiers={'block_size': bs})

--- a/wa/workloads/sysbench/__init__.py
+++ b/wa/workloads/sysbench/__init__.py
@@ -135,16 +135,16 @@ class Sysbench(Workload):
 
         with open(self.host_results_file) as fh:
             find_line_with('General statistics:', fh)
-            extract_metric('total time', fh.next(), context.output)
-            extract_metric('total number of events', fh.next(), context.output, lower_is_better=False)
+            extract_metric('total time', next(fh), context.output)
+            extract_metric('total number of events', next(fh), context.output, lower_is_better=False)
             find_line_with('response time:', fh)
-            extract_metric('min', fh.next(), context.output, 'response time ')
-            extract_metric('avg', fh.next(), context.output, 'response time ')
-            extract_metric('max', fh.next(), context.output, 'response time ')
-            extract_metric('approx.  95 percentile', fh.next(), context.output)
+            extract_metric('min', next(fh), context.output, 'response time ')
+            extract_metric('avg', next(fh), context.output, 'response time ')
+            extract_metric('max', next(fh), context.output, 'response time ')
+            extract_metric('approx.  95 percentile', next(fh), context.output)
             find_line_with('Threads fairness:', fh)
-            extract_threads_fairness_metric('events', fh.next(), context.output)
-            extract_threads_fairness_metric('execution time', fh.next(), context.output)
+            extract_threads_fairness_metric('events', next(fh), context.output)
+            extract_threads_fairness_metric('execution time', next(fh), context.output)
 
     def teardown(self, context):
         self.target.remove(self.target_results_file)
@@ -155,7 +155,7 @@ class Sysbench(Workload):
 
     def _build_command(self, **parameters):
         param_strings = ['--{}={}'.format(k.replace('_', '-'), v)
-                         for k, v in parameters.iteritems()]
+                         for k, v in parameters.items()]
         if self.file_test_mode:
             param_strings.append('--file-test-mode={}'.format(self.file_test_mode))
         sysbench_command = '{} {} {} run'.format(self.target_binary, ' '.join(param_strings), self.cmd_params)

--- a/wa/workloads/vellamo/__init__.py
+++ b/wa/workloads/vellamo/__init__.py
@@ -17,7 +17,7 @@ import os
 import json
 import re
 
-from HTMLParser import HTMLParser
+from html.parser import HTMLParser
 
 from wa import ApkUiautoWorkload, Parameter
 from wa.utils.types import list_of_strs
@@ -48,7 +48,7 @@ class Vellamo(ApkUiautoWorkload):
         '3.0': ['Browser', 'Metal', 'Multi'],
         '3.2.4': ['Browser', 'Metal', 'Multi'],
     }
-    valid_versions = benchmark_types.keys()
+    valid_versions = list(benchmark_types.keys())
     summary_metrics = None
 
     parameters = [
@@ -119,7 +119,7 @@ class Vellamo(ApkUiautoWorkload):
                     benchmark.name = benchmark.name.replace(' ', '_')
                     context.add_metric('{}_Total'.format(benchmark.name),
                                                                 benchmark.score)
-                    for name, score in benchmark.metrics.items():
+                    for name, score in list(benchmark.metrics.items()):
                         name = name.replace(' ', '_')
                         context.add_metric('{}_{}'.format(benchmark.name,
                                                                  name), score)


### PR DESCRIPTION
Add support for running under Python 3, while maintaining compatibility
with Python 2.

NOTE: this introduces a new dependency on the `future` package (which provides 2-3 interop)

See http://python-future.org/compatible_idioms.html for more details
behind these changes.

This depends on https://github.com/ARM-software/devlib/pull/270