### PR TITLE
fw/execution: fix get_resource with strict=False

### DIFF
--- a/wa/framework/execution.py
+++ b/wa/framework/execution.py
@@ -184,6 +184,8 @@ class ExecutionContext(object):
 
     def get_resource(self, resource, strict=True):
         result = self.resolver.get(resource, strict)
+        if result is None:
+            return result
         if os.path.isfile(result):
             with open(result, 'rb') as fh:
                 md5hash = hashlib.md5(fh.read())


### PR DESCRIPTION
If strict=False, resolver.get_resource will return None, rather
than raising NotFoundError. Do not attempt to record the md5 hash in
that case.