### PR TITLE
fw/target: fix signals reboot on unresponsive

### DIFF
--- a/doc/source/instrument_method_map.template
+++ b/doc/source/instrument_method_map.template
@@ -19,3 +19,16 @@ were registered). The table below shows the mapping of the decorator to the
 corresponding priority:
 
 $priority_prefixes
+
+
+Unresponsive Targets
+~~~~~~~~~~~~~~~~~~~~
+
+If a target is believed to be unresponsive, instrument callbacks will be
+disabled to prevent a cascade of errors and potential corruptions of state, as
+it is generally assumed that instrument callbacks will want to do something with
+the target.
+
+If your callback only does something with the host, and does not require an
+active target connection, you can decorate it with ``@hostside`` decorator to
+ensure it gets invoked even if the target becomes unresponsive.

--- a/wa/__init__.py
+++ b/wa/__init__.py
@@ -8,7 +8,7 @@ from wa.framework.exception import (CommandError, ConfigError, HostError, Instru
                                     TargetNotRespondingError, TimeoutError, ToolError,
                                     ValidationError, WAError, WorkloadError, WorkerThreadError)
 from wa.framework.instrument import (Instrument, extremely_slow, very_slow, slow, normal, fast,
-                                     very_fast, extremely_fast)
+                                     very_fast, extremely_fast, hostside)
 from wa.framework.output import RunOutput, discover_wa_outputs
 from wa.framework.output_processor import OutputProcessor
 from wa.framework.plugin import Plugin, Parameter, Alias

--- a/wa/framework/execution.py
+++ b/wa/framework/execution.py
@@ -454,10 +454,11 @@ class Runner(object):
             self.initialize_run()
             self.send(signal.RUN_INITIALIZED)
 
-            while self.context.job_queue:
-                if self.context.run_interrupted:
-                    raise KeyboardInterrupt()
-                self.run_next_job(self.context)
+            with signal.wrap('JOB_QUEUE_EXECUTION', self, self.context):
+                while self.context.job_queue:
+                    if self.context.run_interrupted:
+                        raise KeyboardInterrupt()
+                    self.run_next_job(self.context)
 
         except KeyboardInterrupt as e:
             log.log_error(e, self.logger)

--- a/wa/framework/execution.py
+++ b/wa/framework/execution.py
@@ -388,13 +388,13 @@ class Executor(object):
 
         self.logger.info('Starting run')
         runner = Runner(context, pm)
-        signal.send(signal.RUN_STARTED, self)
+        signal.send(signal.RUN_STARTED, self, context)
         try:
             runner.run()
         finally:
             context.finalize()
             self.execute_postamble(context, output)
-            signal.send(signal.RUN_COMPLETED, self)
+            signal.send(signal.RUN_COMPLETED, self, context)
 
     def execute_postamble(self, context, output):
         self.logger.info('Done.')

--- a/wa/framework/execution.py
+++ b/wa/framework/execution.py
@@ -491,7 +491,7 @@ class Runner(object):
         self.logger.info('Finalizing run')
         self.context.end_run()
         self.pm.enable_all()
-        with signal.wrap('RUN_OUTPUT_PROCESSED'):
+        with signal.wrap('RUN_OUTPUT_PROCESSED', self):
             self.pm.process_run_output(self.context)
             self.pm.export_run_output(self.context)
         self.pm.finalize()

--- a/wa/framework/execution.py
+++ b/wa/framework/execution.py
@@ -506,10 +506,10 @@ class Runner(object):
             log.indent()
             if self.context.reboot_policy.reboot_on_each_job:
                 self.logger.info('Rebooting on new job.')
-                self.context.tm.reboot()
+                self.context.tm.reboot(context)
             elif self.context.reboot_policy.reboot_on_each_spec and context.spec_changed:
                 self.logger.info('Rebooting on new spec.')
-                self.context.tm.reboot()
+                self.context.tm.reboot(context)
 
             with signal.wrap('JOB', self, context):
                 context.tm.start()
@@ -526,7 +526,7 @@ class Runner(object):
             if isinstance(e, TargetNotRespondingError):
                 raise e
             elif isinstance(e, TargetError):
-                context.tm.verify_target_responsive(context.reboot_policy.can_reboot)
+                context.tm.verify_target_responsive(context)
         finally:
             self.logger.info('Completing job {}'.format(job.id))
             self.send(signal.JOB_COMPLETED)
@@ -558,7 +558,7 @@ class Runner(object):
             job.set_status(Status.FAILED)
             log.log_error(e, self.logger)
             if isinstance(e, TargetError) or isinstance(e, TimeoutError):
-                context.tm.verify_target_responsive(context.reboot_policy.can_reboot)
+                context.tm.verify_target_responsive(context)
             self.context.record_ui_state('setup-error')
             raise e
 
@@ -574,7 +574,7 @@ class Runner(object):
                 job.set_status(Status.FAILED)
                 log.log_error(e, self.logger)
                 if isinstance(e, TargetError) or isinstance(e, TimeoutError):
-                    context.tm.verify_target_responsive(context.reboot_policy.can_reboot)
+                    context.tm.verify_target_responsive(context)
                 self.context.record_ui_state('run-error')
                 raise e
             finally:
@@ -586,7 +586,7 @@ class Runner(object):
                 except Exception as e:
                     job.set_status(Status.PARTIAL)
                     if isinstance(e, TargetError) or isinstance(e, TimeoutError):
-                        context.tm.verify_target_responsive(context.reboot_policy.can_reboot)
+                        context.tm.verify_target_responsive(context)
                     self.context.record_ui_state('output-error')
                     raise
 

--- a/wa/framework/instrument.py
+++ b/wa/framework/instrument.py
@@ -140,6 +140,10 @@ SIGNAL_MAP = OrderedDict([
     ('on_job_failure', signal.JOB_FAILED),
     ('on_job_abort', signal.JOB_ABORTED),
 
+    ('before_job_queue_execution', signal.BEFORE_JOB_QUEUE_EXECUTION),
+    ('on_successful_job_queue_exection', signal.SUCCESSFUL_JOB_QUEUE_EXECUTION),
+    ('after_job_queue_execution', signal.AFTER_JOB_QUEUE_EXECUTION),
+
     ('before_job', signal.BEFORE_JOB),
     ('on_successful_job', signal.SUCCESSFUL_JOB),
     ('after_job', signal.AFTER_JOB),

--- a/wa/framework/instrument.py
+++ b/wa/framework/instrument.py
@@ -259,7 +259,7 @@ class ManagedCallback(object):
                 if isinstance(e, WorkloadError):
                     context.set_status('FAILED')
                 elif isinstance(e, TargetError) or isinstance(e, TimeoutError):
-                    context.tm.verify_target_responsive(context.reboot_policy.can_reboot)
+                    context.tm.verify_target_responsive(context)
                 else:
                     if context.current_job:
                         context.set_status('PARTIAL')

--- a/wa/framework/signal.py
+++ b/wa/framework/signal.py
@@ -128,7 +128,6 @@ BEFORE_WORKLOAD_FINALIZED = Signal('before-workload-finalized', invert_priority=
 SUCCESSFUL_WORKLOAD_FINALIZED = Signal('successful-workload-finalized')
 AFTER_WORKLOAD_FINALIZED = Signal('after-workload-finalized')
 
-
 # Signals indicating exceptional conditions
 ERROR_LOGGED = Signal('error-logged')
 WARNING_LOGGED = Signal('warning-logged')
@@ -145,6 +144,10 @@ AFTER_RUN_INIT = Signal('after-run-init')
 BEFORE_JOB = Signal('before-job', invert_priority=True)
 SUCCESSFUL_JOB = Signal('successful-job')
 AFTER_JOB = Signal('after-job')
+
+BEFORE_JOB_QUEUE_EXECUTION = Signal('before-job-queue-execution', invert_priority=True)
+SUCCESSFUL_JOB_QUEUE_EXECUTION = Signal('successful-job-queue-execution')
+AFTER_JOB_QUEUE_EXECUTION = Signal('after-job-queue-execution')
 
 BEFORE_JOB_TARGET_CONFIG = Signal('before-job-target-config', invert_priority=True)
 SUCCESSFUL_JOB_TARGET_CONFIG = Signal('successful-job-target-config')


### PR DESCRIPTION
Call self.reboot() instead of self.target.reboot() when attempting a
reset for unresponsive targets inside TargetManager, in order to ensure
that appropriate signals are dispatched.