### PR TITLE
utils/serializer: add basestring to POD_TYPES

### DIFF
--- a/wa/utils/serializer.py
+++ b/wa/utils/serializer.py
@@ -72,7 +72,7 @@ POD_TYPES = [
     tuple,
     dict,
     set,
-    str,
+    basestring,
     str,
     int,
     float,


### PR DESCRIPTION
Was replaced with str during Python 3 porting.