### PR TITLE
fw/entrypoint: make command mandatory for Python 3

### DIFF
--- a/wa/framework/entrypoint.py
+++ b/wa/framework/entrypoint.py
@@ -101,7 +101,9 @@ def main():
         logger.debug('Command Line: {}'.format(' '.join(sys.argv)))
 
         # each command will add its own subparser
-        commands = load_commands(parser.add_subparsers(dest='command'))
+        subparsers = parser.add_subparsers(dest='command')
+        subparsers.required = True
+        commands = load_commands(subparsers)
         args = parser.parse_args(argv)
 
         config = ConfigManager()


### PR DESCRIPTION
Python 3 has changed the behavior of subparsers so that they are no
longer mandatory by default. As a result, executing just "wa" under
Python 3 results in a random error, rather than a help message.

Fix this by making the subparsers mandatory.