### PR TITLE
framework/version: Redirect git stderr output

### DIFF
--- a/wa/framework/version.py
+++ b/wa/framework/version.py
@@ -41,7 +41,7 @@ def get_wa_version_with_commit():
 
 def get_commit():
     p = Popen(['git', 'rev-parse', 'HEAD'],
-              cwd=os.path.dirname(__file__), stdout=PIPE)
+              cwd=os.path.dirname(__file__), stdout=PIPE, stderr=PIPE)
     std, _ = p.communicate()
     p.wait()
     if p.returncode:


### PR DESCRIPTION
Add an stderr argument to redirect errors ('fatal not a git repository'
is the most common) to PIPE so that errors do not output to STDOUT.