### PR TITLE
framework/command: Fix subparsers in Python3

### DIFF
--- a/wa/framework/command.py
+++ b/wa/framework/command.py
@@ -111,6 +111,7 @@ class ComplexCommand(Command):
 
     def initialize(self, context):
         subparsers = self.parser.add_subparsers(dest='what', metavar='SUBCMD')
+        subparsers.required = True
         for subcmd_cls in self.subcmd_classes:
             subcmd = subcmd_cls(self.logger, subparsers)
             self.subcommands.append(subcmd)


### PR DESCRIPTION
Make subcommands required arguments in the ComplexCommand class, which
is used by the 'wa create' command.