### PR TITLE
commands/revent: Add dummy method to LightContext

### DIFF
--- a/wa/commands/revent.py
+++ b/wa/commands/revent.py
@@ -294,4 +294,7 @@ class LightContext(object):
     def get_resource(self, resource, strict=True):
         return self.resolver.get(resource, strict)
 
+    def update_metadata(self, key, *args):
+        pass
+
     get = get_resource


### PR DESCRIPTION
Add a dummy method to the LightContext to satisfy the API as we
do not record metadata when performing revent recordings.