### PR TITLE
workloads: Fix incorrect attribute name

### DIFF
--- a/wa/workloads/chrome/__init__.py
+++ b/wa/workloads/chrome/__init__.py
@@ -54,7 +54,7 @@ class Chrome(ApkUiautoWorkload):
         super(Chrome, self).__init__(target, **kwargs)
         if self.offline_mode:
             self.deployable_assets = ['pages.tar', 'OfflinePages.db']
-            self.clean_assets = True
+            self.cleanup_assets = True
 
     def initialize(self, context):
         super(Chrome, self).initialize(context)

--- a/wa/workloads/gmail/__init__.py
+++ b/wa/workloads/gmail/__init__.py
@@ -81,7 +81,7 @@ class Gmail(ApkUiautoWorkload):
         self.deployable_assets = [self.test_image]
         if self.offline_mode:
             self.deployable_assets.append('mailstore.tar')
-        self.clean_assets = True
+        self.cleanup_assets = True
 
     def initialize(self, context):
         super(Gmail, self).initialize(context)


### PR DESCRIPTION
Correct setting of attribute `clean_assets` to `cleanup_assets`