### PR TITLE
workloads/chrome: fix docs

### DIFF
--- a/wa/workloads/chrome/__init__.py
+++ b/wa/workloads/chrome/__init__.py
@@ -5,26 +5,30 @@ class Chrome(ApkUiautoWorkload):
 
     name = 'chrome'
     description = '''
-    A workload to perform standard Web browsing tasks with Google Chrome. The workload carries
-    out a number of typical Web-based tasks, navigating through a handful of Wikipedia pages
-    in multiple browser tabs.
+    A workload to perform standard Web browsing tasks with Google Chrome. The
+    workload carries out a number of typical Web-based tasks, navigating through
+    a handful of Wikipedia pages in multiple browser tabs.
 
-    To run the workload in offline mode, a 'pages.tar' archive and an 'OfflinePages.db' file
-    are required. For users wishing to generate these files themselves, Chrome should first be
-    operated from an Internet-connected environment and the following Wikipedia pages should be
-    downloaded for offline use within Chrome:
+    To run the workload in offline mode, a ``pages.tar`` archive and an
+    ``OfflinePages.db`` file are required. For users wishing to generate these
+    files themselves, Chrome should first be operated from an Internet-connected
+    environment and the following Wikipedia pages should be downloaded for
+    offline use within Chrome:
 
     - https://en.m.wikipedia.org/wiki/Main_Page
     - https://en.m.wikipedia.org/wiki/United_States
     - https://en.m.wikipedia.org/wiki/California
 
-    Following this, the files of interest for viewing these pages offline can be found in the
-    '/data/data/com.android.chrome/app_chrome/Default/Offline Pages' directory. The 'OfflinePages.db'
-    file can be copied from the 'metadata' subdirectory, while the ``*.mhtml`` files that should make
-    up the 'pages.tar' file can be found in the 'archives' subdirectory. These page files can then be
-    archived to produce a tarball using a command such as ``tar -cvf pages.tar -C /path/to/archives .``.
-    Both this and 'OfflinePages.db' should then be placed in the '~/.workload_automation/dependencies/chrome/'
-    directory on your local machine, creating this if it does not already exist.
+    Following this, the files of interest for viewing these pages offline can be
+    found in the ``/data/data/com.android.chrome/app_chrome/Default/Offline
+    Pages`` directory. The ``OfflinePages.db`` file can be copied from the
+    'metadata' subdirectory, while the ``*.mhtml`` files that should make up the
+    ``pages.tar`` file can be found in the 'archives' subdirectory. These page
+    files can then be archived to produce a tarball using a command such as
+    ``tar -cvf pages.tar -C /path/to/archives .``.  Both this and
+    ``OfflinePages.db`` should then be placed in the
+    ``~/.workload_automation/dependencies/chrome/`` directory on your local
+    machine, creating this if it does not already exist.
 
     Known working APK version: 65.0.3325.109
     '''
@@ -33,11 +37,11 @@ class Chrome(ApkUiautoWorkload):
     parameters = [
         Parameter('offline_mode', kind=bool, default=False, description='''
                   If set to ``True``, the workload will execute in offline mode.
-                  This mode requires root and makes use of a tarball of *.mhtml
+                  This mode requires root and makes use of a tarball of \*.mhtml
                   files 'pages.tar' and an metadata database 'OfflinePages.db'.
                   The tarball is extracted directly to the application's offline
-                  pages 'archives' directory, while the database is copied to the
-                  offline pages 'metadata' directory.
+                  pages 'archives' directory, while the database is copied to
+                  the offline pages 'metadata' directory.
                   '''),
     ]
 


### PR DESCRIPTION
- Escape asterisk (otherwise, it is interpreted as "open emphasis")
- Use monospace formatting for paths.
- Trim to 79 columns wide