### PR TITLE
gitignore: Update to reflect new doc structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,6 @@ libs/armeabi
 **/uiauto/**/.project
 **/uiauto/**/.settings
 **/uiauto/**/.classpath
-doc/source/developer_reference/instrument_method_map.rst
+doc/source/developer_guide/instrument_method_map.rst
 doc/source/run_config/
 .eggs


### PR DESCRIPTION
Update the location of the instrument method map with the new structure
for the documentation.