### PR TITLE
workloads/deepbench: lengthen timeout

### DIFF
--- a/wa/workloads/deepbench/__init__.py
+++ b/wa/workloads/deepbench/__init__.py
@@ -104,7 +104,7 @@ class Deepbench(Workload):
     def run(self, context):
         self.output = None
         try:
-            timeout = 10800 if self.test == 'sparse' else 600
+            timeout = 10800
             self.output = self.target.execute(self.target_exe, timeout=timeout)
         except KeyboardInterrupt:
             self.target.killall(self.exe_name)


### PR DESCRIPTION
Lengthen timeout for gemm and conv tests to be the same as for sparse
test. While the former two usually take a lot less time, their execution
time will vary significantly depending on the target and the runtime
environment (e.g. cpu frequencies might be forced to lowest values).