### PR TITLE
fw/version: Change format of version to conform with PEP440

### DIFF
--- a/wa/framework/version.py
+++ b/wa/framework/version.py
@@ -34,7 +34,7 @@ def get_wa_version_with_commit():
     version_string = get_wa_version()
     commit = get_commit()
     if commit:
-        return '{}-{}'.format(version_string, commit)
+        return '{}+{}'.format(version_string, commit)
     else:
         return version_string
 


### PR DESCRIPTION
When installing from source WA attempts to include the commit ID in the
version of the installed pacakge however this caused issues with package
managers like pip. PEP440 specifies that local identifiers must be in the
form `<public version identifier>[+<localversion label>]` so update the
version to conform.

https://www.python.org/dev/peps/pep-0440/#local-version-identifiers