### PR TITLE
workloads/jankbench: Update to check if running in a container.

### DIFF
--- a/wa/workloads/jankbench/__init__.py
+++ b/wa/workloads/jankbench/__init__.py
@@ -97,7 +97,7 @@ class Jankbench(ApkWorkload):
         elif self.pull_results_db and not self.target.is_rooted:
             raise ConfigError('pull_results_db set for an unrooted device')
 
-        if self.target.os is 'android':
+        if not self.target.is_container:
             self.target.ensure_screen_is_on()
 
         self.command = self._build_command()


### PR DESCRIPTION
Instead of using the os to determine whether the screen state should
be checked, use target flag to see if running inside a container.

Dependant on https://github.com/ARM-software/devlib/pull/296