### PR TITLE
tests: quieten signal logger

### DIFF
--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+import logging
 import unittest
 
 from nose.tools import assert_equal, assert_true, assert_false
@@ -30,6 +31,11 @@ class Callable(object):
 
 
 class TestPriorityDispatcher(unittest.TestCase):
+
+    def setUp(self):
+        # Stop logger output interfering with nose output in the console.
+        logger = logging.getLogger('signal')
+        logger.setLevel(logging.CRITICAL)
 
     def test_ConnectNotify(self):
         one = Callable(1)


### PR DESCRIPTION
Set signal logger level to CRITICAL to prevent it from spewing out
log message on the console for expected errors during tests.