### PR TITLE
fw/output: update internal state on write_config()

### DIFF
--- a/wa/framework/output.py
+++ b/wa/framework/output.py
@@ -269,6 +269,7 @@ class RunOutput(Output):
         write_pod(self.state.to_pod(), self.statefile)
 
     def write_config(self, config):
+        self._combined_config = config
         write_pod(config.to_pod(), self.configfile)
 
     def read_config(self):


### PR DESCRIPTION
Update the internal _combined_config object with the one that
has been written to ensure that the serialized and run time states are
the same.