### PR TITLE
Cache TargetInfo

### DIFF
--- a/wa/framework/configuration/core.py
+++ b/wa/framework/configuration/core.py
@@ -498,6 +498,10 @@ class MetaConfiguration(Configuration):
     def additional_packages_file(self):
         return os.path.join(self.user_directory, 'packages')
 
+    @property
+    def target_info_cache_file(self):
+        return os.path.join(self.cache_directory, 'targets.json')
+
     def __init__(self, environ=None):
         super(MetaConfiguration, self).__init__()
         if environ is None:

--- a/wa/framework/configuration/core.py
+++ b/wa/framework/configuration/core.py
@@ -483,6 +483,10 @@ class MetaConfiguration(Configuration):
         return os.path.join(self.user_directory, 'plugins')
 
     @property
+    def cache_directory(self):
+        return os.path.join(self.user_directory, 'cache')
+
+    @property
     def plugin_paths(self):
         return [self.plugins_directory] + (self.extra_plugin_paths or [])
 

--- a/wa/framework/host.py
+++ b/wa/framework/host.py
@@ -42,6 +42,7 @@ def init_user_directory(overwrite_existing=False):  # pylint: disable=R0914
     os.makedirs(settings.user_directory)
     os.makedirs(settings.dependencies_directory)
     os.makedirs(settings.plugins_directory)
+    os.makedirs(settings.cache_directory)
 
     generate_default_config(os.path.join(settings.user_directory, 'config.yaml'))
 

--- a/wa/framework/target/manager.py
+++ b/wa/framework/target/manager.py
@@ -24,7 +24,7 @@ from wa.framework.plugin import Parameter
 from wa.framework.target.descriptor import (get_target_description,
                                             instantiate_target,
                                             instantiate_assistant)
-from wa.framework.target.info import get_target_info
+from wa.framework.target.info import get_target_info, get_target_info_from_cache, cache_target_info
 from wa.framework.target.runtime_parameter_manager import RuntimeParameterManager
 
 
@@ -89,7 +89,11 @@ class TargetManager(object):
 
     @memoized
     def get_target_info(self):
-        return get_target_info(self.target)
+        info = get_target_info_from_cache(self.target.system_id)
+        if info is None:
+            info = get_target_info(self.target)
+            cache_target_info(info)
+        return info
 
     def reboot(self, context, hard=False):
         with signal.wrap('REBOOT', self, context):


### PR DESCRIPTION
Use the newly-added system_id to cache TargetInfo objects. Attempt to retrieve
them from cache before querying target, in order to speed up execution.

On my setup, this reduced execution time for a  single dhrystone run on an
SSH-connected target from 49s to 35s, resulting in a speed up of 14s, or 29%.