### PR TITLE
travis: Force version 1.9.2 of pylint to be used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
     - pip install nose
     - pip install nose2
     - pip install flake8
-    - pip install pylint
+    - pip install pylint==1.9.2
     - git clone -v https://github.com/ARM-software/devlib.git /tmp/devlib && cd /tmp/devlib && python setup.py install
     - cd $TRAVIS_BUILD_DIR && python setup.py install
 


### PR DESCRIPTION
Force version 1.9.2 of pylint to be used rather than 2.0.0. Currently
there appears to be issues raising errors that are explicitly ignored.