### PR TITLE
fw/execution: Ensure that identifiers are used when retrieving plugins.

### DIFF
--- a/wa/framework/configuration/execution.py
+++ b/wa/framework/configuration/execution.py
@@ -18,6 +18,8 @@ from itertools import groupby, chain
 
 from future.moves.itertools import zip_longest
 
+from devlib.utils.types import identifier
+
 from wa.framework.configuration.core import (MetaConfiguration, RunConfiguration,
                                              JobGenerator, settings)
 from wa.framework.configuration.parsers import ConfigParser
@@ -99,7 +101,7 @@ class ConfigManager(object):
         self.loaded_config_sources.append(source)
 
     def get_plugin(self, name=None, kind=None, *args, **kwargs):
-        return self.plugin_cache.get_plugin(name, kind, *args, **kwargs)
+        return self.plugin_cache.get_plugin(identifier(name), kind, *args, **kwargs)
 
     def get_instruments(self, target):
         instruments = []


### PR DESCRIPTION
Make sure that when retrieving plugin information from the plugin
cache the name is converted to an identifier first.