### PR TITLE
Expose context in OP initialize and finalize

### DIFF
--- a/doc/source/developer_information/developer_guide/writing_plugins.rst
+++ b/doc/source/developer_information/developer_guide/writing_plugins.rst
@@ -343,7 +343,7 @@ see the
 
             A list of additional :class:`Parameters` the output processor can take.
 
-    :initialize():
+    :initialize(context):
 
                 This method will only be called once during the workload run
                 therefore operations that only need to be performed initially should
@@ -373,7 +373,7 @@ see the
                 existing data collected/generated for the run as a whole. E.g.
                 uploading them to a database etc.
 
-    :finalize():
+    :finalize(context):
 
                 This method is the complement to the initialize method and will also
                 only be called once.

--- a/wa/commands/process.py
+++ b/wa/commands/process.py
@@ -106,7 +106,7 @@ class ProcessCommand(Command):
                         pm.install(proc, pc)
 
             pm.validate()
-            pm.initialize()
+            pm.initialize(pc)
 
             pc.run_output = run_output
             pc.target_info = run_output.target_info
@@ -139,7 +139,7 @@ class ProcessCommand(Command):
             self.logger.info('Processing run')
             pm.process_run_output(pc)
             pm.export_run_output(pc)
-            pm.finalize()
+            pm.finalize(pc)
 
             run_output.write_result()
             self.logger.info('Done.')

--- a/wa/framework/execution.py
+++ b/wa/framework/execution.py
@@ -516,7 +516,7 @@ class Runner(object):
         signal.connect(self._error_signalled_callback, signal.ERROR_LOGGED)
         signal.connect(self._warning_signalled_callback, signal.WARNING_LOGGED)
         self.context.start_run()
-        self.pm.initialize()
+        self.pm.initialize(self.context)
         with log.indentcontext():
             self.context.initialize_jobs()
         self.context.write_state()
@@ -532,7 +532,7 @@ class Runner(object):
         with signal.wrap('RUN_OUTPUT_PROCESSED', self):
             self.pm.process_run_output(self.context)
             self.pm.export_run_output(self.context)
-        self.pm.finalize()
+        self.pm.finalize(self.context)
         signal.disconnect(self._error_signalled_callback, signal.ERROR_LOGGED)
         signal.disconnect(self._warning_signalled_callback, signal.WARNING_LOGGED)
 

--- a/wa/framework/output_processor.py
+++ b/wa/framework/output_processor.py
@@ -40,10 +40,10 @@ class OutputProcessor(Plugin):
                 msg = 'Instrument "{}" is required by {}, but is not installed.'
                 raise ConfigError(msg.format(instrument, self.name))
 
-    def initialize(self):
+    def initialize(self, context):
         pass
 
-    def finalize(self):
+    def finalize(self, context):
         pass
 
 
@@ -104,13 +104,13 @@ class ProcessorManager(object):
         for proc in self.processors:
             proc.validate()
 
-    def initialize(self):
+    def initialize(self, context):
         for proc in self.processors:
-            proc.initialize()
+            proc.initialize(context)
 
-    def finalize(self):
+    def finalize(self, context):
         for proc in self.processors:
-            proc.finalize()
+            proc.finalize(context)
 
     def process_job_output(self, context):
         self.do_for_each_proc('process_job_output', 'Processing using "{}"',

--- a/wa/output_processors/cpustates.py
+++ b/wa/output_processors/cpustates.py
@@ -85,7 +85,7 @@ class CpuStatesProcessor(OutputProcessor):
                   """),
     ]
 
-    def initialize(self):
+    def initialize(self, context):
         self.iteration_reports = OrderedDict()  # pylint: disable=attribute-defined-outside-init
 
     def process_job_output(self, output, target_info, run_output):  # pylint: disable=unused-argument

--- a/wa/output_processors/csvproc.py
+++ b/wa/output_processors/csvproc.py
@@ -56,7 +56,7 @@ class CsvReportProcessor(OutputProcessor):
                   'use_all_classifiers is True'
             raise ConfigError(msg)
 
-    def initialize(self):
+    def initialize(self, context):
         # pylint: disable=attribute-defined-outside-init
         self.outputs_so_far = []
         self.artifact_added = False

--- a/wa/output_processors/sqlite.py
+++ b/wa/output_processors/sqlite.py
@@ -108,7 +108,7 @@ class SqliteResultProcessor(OutputProcessor):
 
     ]
 
-    def initialize(self):
+    def initialize(self, context):
         self._last_spec = None
         self._run_oid = None
         self._spec_oid = None

--- a/wa/output_processors/targz.py
+++ b/wa/output_processors/targz.py
@@ -56,7 +56,7 @@ class TargzProcessor(OutputProcessor):
                   '''),
     ]
 
-    def initialize(self):
+    def initialize(self, context):
         if self.delete_output:
             self.logger.debug('Registering RUN_FINALIZED handler.')
             signal.connect(self.delete_output_directory, signal.RUN_FINALIZED, priority=-100)


### PR DESCRIPTION
Expose the context to the initialize and finalize functions for Output
Processors. This was found to be necessary for the upcoming PostgreSQL
Output Processor.