### PR TITLE
configuration: Add support for section groups

### DIFF
--- a/doc/source/user_information/how_tos/agenda.rst
+++ b/doc/source/user_information/how_tos/agenda.rst
@@ -489,6 +489,75 @@ Note that the ``config`` section still applies to every spec in the agenda. So
 the precedence order is -- spec settings override section settings, which in
 turn override global settings.
 
+
+.. _section-groups:
+
+Section Groups
+---------------
+
+Section groups are a way of grouping sections together and are used to produce a
+cross product of each of the different groups. This can be useful when you want
+to run a set of experiments with all the available combinations without having
+to specify each combination manually.
+
+For example if we want to investigate the differences between running the
+maximum and minimum frequency with both the maximum and minimum number of cpus
+online, we can create an agenda as follows:
+
+.. code-block:: yaml
+
+        sections:
+          - id: min_freq
+          runtime_parameters:
+              freq: min
+          group: frequency
+         - id: max_freq
+          runtime_parameters:
+              freq: max
+         group: frequency
+
+         - id: min_cpus
+           runtime_parameters:
+              cpus: 1
+         group: cpus
+         - id: max_cpus
+           runtime_parameters:
+              cpus: 8
+         group: cpus
+
+        workloads:
+        -  dhrystone
+
+This will results in 8 jobs being generated for each of the possible combinations.
+
+::
+
+      min_freq-min_cpus-wk1 (dhrystone)
+      min_freq-max_cpus-wk1 (dhrystone)
+      max_freq-min_cpus-wk1 (dhrystone)
+      max_freq-max_cpus-wk1 (dhrystone)
+      min_freq-min_cpus-wk1 (dhrystone)
+      min_freq-max_cpus-wk1 (dhrystone)
+      max_freq-min_cpus-wk1 (dhrystone)
+      max_freq-max_cpus-wk1 (dhrystone)
+
+Each of the generated jobs will have :ref:`classifiers <classifiers>` for
+each group and the associated id automatically added.
+
+.. code-block:: python
+
+      # ...
+      print('Job ID: {}'.format(job.id))
+      print('Classifiers:')
+      for k, v in job.classifiers.items():
+          print('  {}: {}'.format(k, v))
+
+      Job ID: min_freq-min_cpus-no_idle-wk1
+      Classifiers:
+          frequency: min_freq
+          cpus: min_cpus
+
+
 .. _augmentations:
 
 Augmentations

--- a/wa/framework/configuration/core.py
+++ b/wa/framework/configuration/core.py
@@ -978,8 +978,8 @@ class JobGenerator(object):
         if name == "augmentations":
             self.update_augmentations(value)
 
-    def add_section(self, section, workloads):
-        new_node = self.root_node.add_section(section)
+    def add_section(self, section, workloads, group):
+        new_node = self.root_node.add_section(section, group)
         with log.indentcontext():
             for workload in workloads:
                 new_node.add_workload(workload)
@@ -1041,6 +1041,12 @@ def create_job_spec(workload_entry, sections, target_manager, plugin_cache,
     # PHASE 2.1: Merge general job spec configuration
     for section in sections:
         job_spec.update_config(section, check_mandatory=False)
+
+        # Add classifiers for any present groups
+        if section.id == 'global' or section.group is None:
+            # Ignore global config and default group
+            continue
+        job_spec.classifiers[section.group] = section.id
     job_spec.update_config(workload_entry, check_mandatory=False)
 
     # PHASE 2.2: Merge global, section and workload entry "workload_parameters"

--- a/wa/framework/configuration/parsers.py
+++ b/wa/framework/configuration/parsers.py
@@ -196,9 +196,10 @@ class AgendaParser(object):
                     raise ConfigError(msg.format(json.dumps(section, indent=None)))
                 section['runtime_params'] = section.pop('params')
 
+            group = section.pop('group', None)
             section = _construct_valid_entry(section, seen_sect_ids,
                                              "s", state.jobs_config)
-            state.jobs_config.add_section(section, workloads)
+            state.jobs_config.add_section(section, workloads, group)
 
 
 ########################

--- a/wa/framework/configuration/tree.py
+++ b/wa/framework/configuration/tree.py
@@ -69,14 +69,20 @@ class SectionNode(JobSpecSource):
     def is_leaf(self):
         return not bool(self.children)
 
-    def __init__(self, config, parent=None):
+    def __init__(self, config, parent=None, group=None):
         super(SectionNode, self).__init__(config, parent=parent)
         self.workload_entries = []
         self.children = []
+        self.group = group
 
-    def add_section(self, section):
-        new_node = SectionNode(section, parent=self)
-        self.children.append(new_node)
+    def add_section(self, section, group=None):
+        # Each level is the same group, only need to check first
+        if not self.children or group == self.children[0].group:
+            new_node = SectionNode(section, parent=self, group=group)
+            self.children.append(new_node)
+        else:
+            for child in self.children:
+                new_node = child.add_section(section, group)
         return new_node
 
     def add_workload(self, workload_config):


### PR DESCRIPTION
Now allows for specifying a `group` value for each section which will
cross product the sections within that group with the sections in each
other group. Additionally classifiers will automatically be added to
each job spec with the relevant group information.