### PR TITLE
workloads/jankbench: Ensure logcat monitor thread is terminated

### DIFF
--- a/wa/workloads/jankbench/__init__.py
+++ b/wa/workloads/jankbench/__init__.py
@@ -227,6 +227,7 @@ class JankbenchRunMonitor(threading.Thread):
                         line = line.decode(sys.stdout.encoding, 'replace')
                     if self.regex.search(line):
                         self.run_ended.set()
+        proc.terminate()
 
     def stop(self):
         self.stop_event.set()


### PR DESCRIPTION
Previously the LogcatRunMonitor left the logcat process running in the
background causing issues with concurrent accesses. Now ensure the thread
terminates correctly.