### PR TITLE
Update quoting

### DIFF
--- a/wa/commands/show.py
+++ b/wa/commands/show.py
@@ -20,6 +20,7 @@
 
 import sys
 from subprocess import call, Popen, PIPE
+from pipes import quote
 
 from wa import Command
 from wa.framework import pluginloader
@@ -30,8 +31,6 @@ from wa.utils.types import caseless_string, identifier
 from wa.utils.doc import (strip_inlined_text, get_rst_from_plugin,
                           get_params_rst, underline)
 from wa.utils.misc import which
-
-from devlib.utils.misc import escape_double_quotes
 
 
 class ShowCommand(Command):
@@ -87,7 +86,7 @@ class ShowCommand(Command):
             title = '.TH {}{} 7'.format(kind, plugin_name)
             output = '\n'.join([title, body])
 
-            call('echo "{}" | man -l -'.format(escape_double_quotes(output)), shell=True)
+            call('echo {} | man -l -'.format(quote(output)), shell=True)
         else:
             print(rst_output)  # pylint: disable=superfluous-parens
 

--- a/wa/framework/target/descriptor.py
+++ b/wa/framework/target/descriptor.py
@@ -345,9 +345,9 @@ CONNECTION_PARAMS = {
             """),
         Parameter(
             'sudo_cmd', kind=str,
-            default="sudo -- sh -c '{}'",
+            default="sudo -- sh -c {}",
             description="""
-            Sudo command to use. Must have ``"{}"`` specified
+            Sudo command to use. Must have ``{}`` specified
             somewhere in the string it indicate where the command
             to be run via sudo is to go.
             """),

--- a/wa/utils/misc.py
+++ b/wa/utils/misc.py
@@ -49,7 +49,6 @@ from devlib.exception import TargetError
 from devlib.utils.misc import (ABI_MAP, check_output, walk_modules,
                                ensure_directory_exists, ensure_file_directory_exists,
                                normalize, convert_new_lines, get_cpu_mask, unique,
-                               escape_quotes, escape_single_quotes, escape_double_quotes,
                                isiterable, getch, as_relative, ranges_to_list, memoized,
                                list_to_ranges, list_to_mask, mask_to_list, which,
                                to_identifier)


### PR DESCRIPTION
Dependant on https://github.com/ARM-software/devlib/pull/339.

The escaping methods from devlib are being deprecated in favour of using `quote` from the `pipes` module therefore update references in WA. 
Additionally update parameter default to no longer manually quote a devices sudo command which will no longer be required. 