### PR TITLE
fw/output: Ensure that `Event` message is converted to a string

### DIFF
--- a/wa/framework/output.py
+++ b/wa/framework/output.py
@@ -617,7 +617,7 @@ class Event(object):
 
     def __init__(self, message):
         self.timestamp = datetime.utcnow()
-        self.message = message
+        self.message = str(message)
 
     def to_pod(self):
         return dict(


### PR DESCRIPTION
Explicitly convert the passed message into a string as this is expected when
generating a event summary, otherwise splitting can fail.