### PR TITLE
commands/show: Revert quoting method switch

### DIFF
--- a/wa/commands/show.py
+++ b/wa/commands/show.py
@@ -20,7 +20,8 @@
 
 import sys
 from subprocess import call, Popen, PIPE
-from pipes import quote
+
+from devlib.utils.misc import escape_double_quotes
 
 from wa import Command
 from wa.framework import pluginloader
@@ -86,7 +87,7 @@ class ShowCommand(Command):
             title = '.TH {}{} 7'.format(kind, plugin_name)
             output = '\n'.join([title, body])
 
-            call('echo {} | man -l -'.format(quote(output)), shell=True)
+            call('echo "{}" | man -l -'.format(escape_double_quotes(output)), shell=True)
         else:
             print(rst_output)  # pylint: disable=superfluous-parens
 


### PR DESCRIPTION
In commit bb282eb19c48b5770186d136e8a40c0573ef59b9 devlibs
`escape_double_quotes` method was retired in favour of the `pipes.quote`
method however this does not format correctly for this purpose therefore
revert back to the original escaping method.