### PR TITLE
wa/version: Update to development version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,12 +83,13 @@ params = dict(
         'colorama',  # Printing with colors
         'pyYAML',  # YAML-formatted agenda parsing
         'requests',  # Fetch assets over HTTP
-        'devlib>=1.1.0',  # Interacting with devices
+        'devlib>=1.1.dev1',  # Interacting with devices
         'louie-latest',  # callbacks dispatch
         'wrapt',  # better decorators
         'pandas>=0.23.0',  # Data analysis and manipulation
         'future',  # Python 2-3 compatiblity
     ],
+    dependency_links=['https://github.com/ARM-software/devlib/tarball/master#egg=devlib-1.1.dev1'],
     extras_require={
         'other': ['jinja2'],
         'test': ['nose', 'mock'],

--- a/wa/framework/version.py
+++ b/wa/framework/version.py
@@ -21,7 +21,7 @@ from subprocess import Popen, PIPE
 
 VersionTuple = namedtuple('Version', ['major', 'minor', 'revision'])
 
-version = VersionTuple(3, 1, 0)
+version = VersionTuple(3, 1, 'dev1')
 
 
 def get_wa_version():


### PR DESCRIPTION
Update WA and devlib versions to development tags.

Dependant on https://github.com/ARM-software/devlib/pull/358