### PR TITLE
fw/output: better classifiers format for metrics

### DIFF
--- a/wa/framework/output.py
+++ b/wa/framework/output.py
@@ -37,7 +37,7 @@ from wa.framework.run import RunState, RunInfo
 from wa.framework.target.info import TargetInfo
 from wa.framework.version import get_wa_version_with_commit
 from wa.utils.doc import format_simple_table
-from wa.utils.misc import touch, ensure_directory_exists, isiterable
+from wa.utils.misc import touch, ensure_directory_exists, isiterable, format_ordered_dict
 from wa.utils.postgres import get_schema_versions
 from wa.utils.serializer import write_pod, read_pod, Podable, json
 from wa.utils.types import enum, numeric
@@ -635,7 +635,7 @@ class Metric(Podable):
     def __repr__(self):
         text = self.__str__()
         if self.classifiers:
-            return '<{} {}>'.format(text, self.classifiers)
+            return '<{} {}>'.format(text, format_ordered_dict(self.classifiers))
         else:
             return '<{}>'.format(text)
 

--- a/wa/utils/misc.py
+++ b/wa/utils/misc.py
@@ -626,3 +626,13 @@ def resolve_unique_domain_cpus(name, target):
         if domain_cpus[0] not in unique_cpus:
             unique_cpus.append(domain_cpus[0])
     return unique_cpus
+
+
+def format_ordered_dict(od):
+    """
+    Provide a string representation of ordered dict that is similar to the
+    regular dict representation, as that is more concise and easier to read
+    than the default __str__ for OrderedDict.
+    """
+    return '{{{}}}'.format(', '.join('{}={}'.format(k, v)
+                                     for k, v in od.items()))


### PR DESCRIPTION
Use a dict-like string representation for classifiers, rather than the
default OrderedDict one, which is a lot more verbose and difficult to
read.