### PR TITLE
fw/workload: Add a 'View' parameter to ApkWorkloads

### DIFF
--- a/wa/framework/workload.py
+++ b/wa/framework/workload.py
@@ -235,6 +235,12 @@ class ApkWorkload(Workload):
                   will fall back to the version on the target if available. If
                   ``False`` then the version on the target is preferred instead.
                   """),
+        Parameter('view', kind=str, default=None, merge=True,
+                  description="""
+                  Manually override the 'View' of the workload for use with
+                  instruments such as the ``fps`` instrument. If not specified,
+                  a workload dependant 'View' will be automatically generated.
+                  """),
     ]
 
     @property


### PR DESCRIPTION
Allow for easy configuring of a view for a particular workload as this
can vary depending on the device which can be used when using certain
instruments for example `fps`.