### PR TITLE
output_processors/postgresql: Add missing default

### DIFF
--- a/wa/output_processors/postgresql.py
+++ b/wa/output_processors/postgresql.py
@@ -206,7 +206,7 @@ class PostgresqlResultProcessor(OutputProcessor):
                 target_pod['sched_features'],
                 target_pod['page_size_kb'],
                 # Android Specific
-                list(target_pod.get('screen_resolution')),
+                list(target_pod.get('screen_resolution', [])),
                 target_pod.get('prop'),
                 target_pod.get('android_id'),
                 target_pod.get('pod_version'),


### PR DESCRIPTION
In the case of no screen resolution being present ensure that a default
is used instead of `None`.