### PR TITLE
fw/resource: Fix attempting to match against empty values

### DIFF
--- a/wa/framework/resource.py
+++ b/wa/framework/resource.py
@@ -161,13 +161,13 @@ class ApkFile(Resource):
         package_matches = True
         abi_matches = True
         uiauto_matches = uiauto_test_matches(path, self.uiauto)
-        if self.version is not None:
+        if self.version:
             version_matches = apk_version_matches(path, self.version)
-        if self.variant is not None:
+        if self.variant:
             name_matches = file_name_matches(path, self.variant)
-        if self.package is not None:
+        if self.package:
             package_matches = package_name_matches(path, self.package)
-        if self.supported_abi is not None:
+        if self.supported_abi:
             abi_matches = apk_abi_matches(path, self.supported_abi,
                                           self.exact_abi)
         return name_matches and version_matches and \


### PR DESCRIPTION
Update checking of attributes to allow for empty structures as they can
be set to empty lists etc. and therefore should not be checking if
explicitly `None`.