### PR TITLE
utils/serializer: fix error reporting for YAML 

### DIFF
--- a/wa/utils/serializer.py
+++ b/wa/utils/serializer.py
@@ -259,7 +259,8 @@ class yaml(object):
             lineno = None
             if hasattr(e, 'problem_mark'):
                 lineno = e.problem_mark.line  # pylint: disable=no-member
-            raise SerializerSyntaxError(e.args[0] if e.args else str(e), lineno)
+            message = e.args[0] if (e.args and e.args[0]) else str(e)
+            raise SerializerSyntaxError(message, lineno)
 
     loads = load
 


### PR DESCRIPTION
When attempting to access the message of a exception check not only that
e.args is populated, but also that e.args[0] actually contains
something, before defaulting to str(e).