### PR TITLE
utils/serializer: fix support for YAML anchors.

### DIFF
--- a/wa/utils/serializer.py
+++ b/wa/utils/serializer.py
@@ -259,7 +259,8 @@ class yaml(object):
             lineno = None
             if hasattr(e, 'problem_mark'):
                 lineno = e.problem_mark.line  # pylint: disable=no-member
-            raise SerializerSyntaxError(e.args[0] if e.args else str(e), lineno)
+            message = e.args[0] if (e.args and e.args[0]) else str(e)
+            raise SerializerSyntaxError(message, lineno)
 
     loads = load
 


### PR DESCRIPTION
Change the way maps get processed by YAML constructor to support YAML
features, such as anchors, while still maintaining dict ordering.