### PR TITLE
Port scripts for doc generation to Py3 & Pylint fixes

### DIFF
--- a/doc/build_instrument_method_map.py
+++ b/doc/build_instrument_method_map.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#    Copyright 2015-2015 ARM Limited
+#    Copyright 2015-2019 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ OUTPUT_TEMPLATE_FILE =  os.path.join(os.path.dirname(__file__), 'source', 'instr
 
 
 def generate_instrument_method_map(outfile):
-    signal_table = format_simple_table([(k, v) for k, v in SIGNAL_MAP.iteritems()],
+    signal_table = format_simple_table([(k, v) for k, v in SIGNAL_MAP.items()],
                                        headers=['method name', 'signal'], align='<<')
     priority_table = format_simple_table(zip(CallbackPriority.names, CallbackPriority.values),
                                          headers=['decorator', 'priority'],  align='<>')

--- a/doc/build_instrument_method_map.py
+++ b/doc/build_instrument_method_map.py
@@ -37,4 +37,4 @@ def generate_instrument_method_map(outfile):
 
 
 if __name__ == '__main__':
-    generate_instrumentation_method_map(sys.argv[1])
+    generate_instrument_method_map(sys.argv[1])

--- a/doc/build_plugin_docs.py
+++ b/doc/build_plugin_docs.py
@@ -25,7 +25,12 @@ from wa.utils.doc import (strip_inlined_text, get_rst_from_plugin,
                           get_params_rst, underline, line_break)
 from wa.utils.misc import capitalize
 
-GENERATE_FOR_PACKAGES = ['wa.workloads', 'wa.instruments', 'wa.output_processors']
+GENERATE_FOR_PACKAGES = [
+    'wa.workloads',
+    'wa.instruments',
+    'wa.output_processors',
+]
+
 
 def insert_contents_table(title='', depth=1):
     """
@@ -41,6 +46,7 @@ def insert_contents_table(title='', depth=1):
 
 
 def generate_plugin_documentation(source_dir, outdir, ignore_paths):
+    # pylint: disable=unused-argument
     pluginloader.clear()
     pluginloader.update(packages=GENERATE_FOR_PACKAGES)
     if not os.path.exists(outdir):
@@ -73,9 +79,11 @@ def generate_target_documentation(outdir):
                            'juno_linux',
                            'juno_android']
 
-    intro = '\nThis is a list of commonly used targets and their device '\
-    'parameters, to see a complete for a complete reference please use the '\
-    'WA :ref:`list command <list-command>`.\n\n\n'
+    intro = (
+        '\nThis is a list of commonly used targets and their device '
+        'parameters, to see a complete for a complete reference please use the'
+        ' WA :ref:`list command <list-command>`.\n\n\n'
+    )
 
     pluginloader.clear()
     pluginloader.update(packages=['wa.framework.target.descriptor'])
@@ -112,7 +120,8 @@ def generate_config_documentation(config, outdir):
     if not os.path.exists(outdir):
         os.mkdir(outdir)
 
-    outfile = os.path.join(outdir, '{}.rst'.format('_'.join(config.name.split())))
+    config_name = '_'.join(config.name.split())
+    outfile = os.path.join(outdir, '{}.rst'.format(config_name))
     with open(outfile, 'w') as wfh:
         wfh.write(get_params_rst(config.config_points))
 

--- a/doc/build_plugin_docs.py
+++ b/doc/build_plugin_docs.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#    Copyright 2014-2015 ARM Limited
+#    Copyright 2014-2019 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ def generate_plugin_documentation(source_dir, outdir, ignore_paths):
             exts = pluginloader.list_plugins(ext_type)
             sorted_exts = iter(sorted(exts, key=lambda x: x.name))
             try:
-                wfh.write(get_rst_from_plugin(sorted_exts.next()))
+                wfh.write(get_rst_from_plugin(next(sorted_exts)))
             except StopIteration:
                 return
             for ext in sorted_exts:


### PR DESCRIPTION
Patch to allow building the documentation under Python 3.x (should still work under 2.6+).

Fix an incorrect function name in a script.

Fix `doc/build_plugin_docs.py` according to Pylint and the configuration file in this repository.