### PR TITLE
Teardown improvments

### DIFF
--- a/wa/framework/workload.py
+++ b/wa/framework/workload.py
@@ -42,9 +42,9 @@ class Workload(TargetedPlugin):
                   aliases=['clean_up'],
                   default=True,
                   description="""
-                  If ``True``, if assets are deployed as part of the workload they
-                  will be removed again from the device as part of finalize.
-                  """)
+                  If ``True``, assets that are deployed or created as part of the
+                  workload will be removed again from the device.
+                  """),
     ]
 
     # Set this to True to mark that this workload poses a risk of exposing

--- a/wa/framework/workload.py
+++ b/wa/framework/workload.py
@@ -45,6 +45,12 @@ class Workload(TargetedPlugin):
                   If ``True``, assets that are deployed or created as part of the
                   workload will be removed again from the device.
                   """),
+        Parameter('uninstall', kind=bool,
+                  default=True,
+                  description="""
+                  If ``True``, executables that are installed to the device
+                  as part of the workload will be uninstalled again.
+                  """),
     ]
 
     # Set this to True to mark that this workload poses a risk of exposing
@@ -219,6 +225,7 @@ class ApkWorkload(Workload):
                   """),
         Parameter('uninstall', kind=bool,
                   default=False,
+                  override=True,
                   description="""
                   If ``True``, will uninstall workload\'s APK as part of teardown.'
                   """),

--- a/wa/framework/workload.py
+++ b/wa/framework/workload.py
@@ -352,7 +352,8 @@ class ApkUIWorkload(ApkWorkload):
     @once_per_instance
     def finalize(self, context):
         super(ApkUIWorkload, self).finalize(context)
-        self.gui.remove()
+        if self.cleanup_assets:
+            self.gui.remove()
 
 
 class ApkUiautoWorkload(ApkUIWorkload):
@@ -432,7 +433,8 @@ class UIWorkload(Workload):
     @once_per_instance
     def finalize(self, context):
         super(UIWorkload, self).finalize(context)
-        self.gui.remove()
+        if self.cleanup_assets:
+            self.gui.remove()
 
 
 class UiautoWorkload(UIWorkload):
@@ -628,12 +630,12 @@ class ReventGUI(object):
         if self.revent_teardown_file:
             self.revent_recorder.replay(self.on_target_teardown_revent,
                                         timeout=self.teardown_timeout)
+
+    def remove(self):
         self.target.remove(self.on_target_setup_revent)
         self.target.remove(self.on_target_run_revent)
         self.target.remove(self.on_target_extract_results_revent)
         self.target.remove(self.on_target_teardown_revent)
-
-    def remove(self):
         self.revent_recorder.remove()
 
     def _check_revent_files(self):

--- a/wa/workloads/dhrystone/__init__.py
+++ b/wa/workloads/dhrystone/__init__.py
@@ -153,7 +153,8 @@ class Dhrystone(Workload):
 
     @once
     def finalize(self, context):
-        self.target.uninstall('dhrystone')
+        if self.uninstall:
+            self.target.uninstall('dhrystone')
 
     def validate(self):
         if self.mloops and self.duration:  # pylint: disable=E0203

--- a/wa/workloads/hackbench/__init__.py
+++ b/wa/workloads/hackbench/__init__.py
@@ -90,8 +90,10 @@ class Hackbench(Workload):
                         context.add_metric(label, float(match.group(1)), units)
 
     def teardown(self, context):
-        self.target.execute('rm -f {}'.format(self.target_output_file))
+        if self.cleanup_assets:
+            self.target.execute('rm -f {}'.format(self.target_output_file))
 
     @once
     def finalize(self, context):
-        self.target.uninstall(self.binary_name)
+        if self.uninstall:
+            self.target.uninstall(self.binary_name)

--- a/wa/workloads/hwuitest/__init__.py
+++ b/wa/workloads/hwuitest/__init__.py
@@ -120,5 +120,5 @@ class HWUITest(Workload):
 
     @once
     def finalize(self, context):
-        if self.target_exe:
+        if self.target_exe and self.uninstall:
             self.target.uninstall(self.target_exe)

--- a/wa/workloads/lmbench/__init__.py
+++ b/wa/workloads/lmbench/__init__.py
@@ -116,7 +116,8 @@ class Lmbench(Workload):
         context.add_artifact('lmbench-result', "lmbench.output", kind='raw')
 
     def teardown(self, context):
-        self.target.uninstall(self.test)
+        if self.uninstall:
+            self.target.uninstall(self.test)
 
     #
     # Test setup routines

--- a/wa/workloads/meabo/__init__.py
+++ b/wa/workloads/meabo/__init__.py
@@ -286,7 +286,8 @@ class Meabo(Workload):
                                    int(match.group('duration')), units="ns")
 
     def finalize(self, context):
-        self._uninstall_executable()
+        if self.uninstall:
+            self._uninstall_executable()
 
     def _build_command(self):
         self.command = self.target_exe

--- a/wa/workloads/memcpy/__init__.py
+++ b/wa/workloads/memcpy/__init__.py
@@ -86,4 +86,5 @@ class Memcpy(Workload):
 
     @once
     def finalize(self, context):
-        self.target.uninstall('memcpy')
+        if self.uninstall:
+            self.target.uninstall('memcpy')

--- a/wa/workloads/openssl/__init__.py
+++ b/wa/workloads/openssl/__init__.py
@@ -156,5 +156,5 @@ class Openssl(Workload):
 
     @once
     def finalize(self, context):
-        if not self.use_system_binary:
+        if not self.use_system_binary and self.uninstall:
             self.target.uninstall('openssl')

--- a/wa/workloads/rt_app/__init__.py
+++ b/wa/workloads/rt_app/__init__.py
@@ -130,8 +130,8 @@ class RtApp(Workload):
                   '''),
         Parameter('cpus', kind=cpu_mask, default=0, aliases=['taskset_mask'],
                   description='Constrain execution to specific CPUs.'),
-        Parameter('uninstall_on_exit', kind=bool, default=False,
-                  description="""
+        Parameter('uninstall', aliases=['uninstall_on_exit'], kind=bool, default=False,
+                  override=True, description="""
                   If set to ``True``, rt-app binary will be uninstalled from the device
                   at the end of the run.
                   """),
@@ -213,9 +213,10 @@ class RtApp(Workload):
 
     @once
     def finalize(self, context):
-        if self.uninstall_on_exit:
+        if self.uninstall:
             self.target.uninstall(self.target_binary)
-        self.target.execute('rm -rf {}'.format(self.target_working_directory))
+        if self.cleanup_assets:
+            self.target.execute('rm -rf {}'.format(self.target_working_directory))
 
     def _deploy_rt_app_binary_if_necessary(self):
         # called from initialize() so gets invoked once per run

--- a/wa/workloads/shellscript/__init__.py
+++ b/wa/workloads/shellscript/__init__.py
@@ -67,4 +67,5 @@ class ShellScript(Workload):
             wfh.write(self.output)
 
     def teardown(self, context):
-        self.target.remove(self.on_target_script_file)
+        if self.cleanup_assets:
+            self.target.remove(self.on_target_script_file)

--- a/wa/workloads/stress_ng/__init__.py
+++ b/wa/workloads/stress_ng/__init__.py
@@ -131,4 +131,5 @@ class StressNg(Workload):
 
     @once
     def finalize(self, context):
-        self.target.uninstall('stress-ng')
+        if self.uninstall:
+            self.target.uninstall('stress-ng')

--- a/wa/workloads/sysbench/__init__.py
+++ b/wa/workloads/sysbench/__init__.py
@@ -147,11 +147,13 @@ class Sysbench(Workload):
             extract_threads_fairness_metric('execution time', next(fh), context.output)
 
     def teardown(self, context):
-        self.target.remove(self.target_results_file)
+        if self.cleanup_assets:
+            self.target.remove(self.target_results_file)
 
     @once
     def finalize(self, context):
-        self.target.uninstall('sysbench')
+        if self.uninstall:
+            self.target.uninstall('sysbench')
 
     def _build_command(self, **parameters):
         param_strings = ['--{}={}'.format(k.replace('_', '-'), v)


### PR DESCRIPTION
As per https://github.com/ARM-software/workload-automation/issues/643 for debugging purposes it would be useful to be able to disable the cleanup of workloads. 
Improve the usage of the existing `clean_up` parameter across workloads and add `uninstall` to the base `workload` class to allow the control of uninstalling all executables instead of just apk applications.   