### PR TITLE
Max min version

### DIFF
--- a/wa/framework/resource.py
+++ b/wa/framework/resource.py
@@ -24,7 +24,7 @@ from wa.framework.exception import ResourceError
 from wa.framework.configuration import settings
 from wa.utils import log
 from wa.utils.misc import get_object_name
-from wa.utils.types import enum, list_or_string, prioritylist
+from wa.utils.types import enum, list_or_string, prioritylist, version_tuple
 
 
 SourcePriority = enum(['package', 'remote', 'lan', 'local',
@@ -142,10 +142,12 @@ class ApkFile(Resource):
 
     def __init__(self, owner, variant=None, version=None,
                  package=None, uiauto=False, exact_abi=False,
-                 supported_abi=None):
+                 supported_abi=None, min_version=None, max_version=None):
         super(ApkFile, self).__init__(owner)
         self.variant = variant
         self.version = version
+        self.max_version = max_version
+        self.min_version = min_version
         self.package = package
         self.uiauto = uiauto
         self.exact_abi = exact_abi
@@ -158,11 +160,15 @@ class ApkFile(Resource):
     def match(self, path):
         name_matches = True
         version_matches = True
+        version_range_matches = True
         package_matches = True
         abi_matches = True
         uiauto_matches = uiauto_test_matches(path, self.uiauto)
         if self.version:
             version_matches = apk_version_matches(path, self.version)
+        if self.max_version or self.min_version:
+            version_range_matches = apk_version_matches_range(path, self.min_version,
+                                                              self.max_version)
         if self.variant:
             name_matches = file_name_matches(path, self.variant)
         if self.package:
@@ -171,8 +177,8 @@ class ApkFile(Resource):
             abi_matches = apk_abi_matches(path, self.supported_abi,
                                           self.exact_abi)
         return name_matches and version_matches and \
-            uiauto_matches and package_matches and \
-            abi_matches
+            version_range_matches and uiauto_matches \
+            and package_matches and abi_matches
 
     def __str__(self):
         text = '<{}\'s apk'.format(self.owner)
@@ -281,6 +287,27 @@ def apk_version_matches(path, version):
         if loose_version_matching(v, info.version_name):
             return True
     return False
+
+
+def apk_version_matches_range(path, min_version=None, max_version=None):
+    info = ApkInfo(path)
+    return range_version_matching(info.version_name, min_version, max_version)
+
+
+def range_version_matching(apk_version, min_version=None, max_version=None):
+    if not apk_version:
+        return False
+    apk_version = version_tuple(apk_version)
+
+    if max_version:
+        max_version = version_tuple(max_version)
+        if apk_version > max_version:
+            return False
+    if min_version:
+        min_version = version_tuple(min_version)
+        if apk_version < min_version:
+            return False
+    return True
 
 
 def loose_version_matching(config_version, apk_version):

--- a/wa/framework/resource.py
+++ b/wa/framework/resource.py
@@ -284,8 +284,8 @@ def apk_version_matches(path, version):
 
 
 def loose_version_matching(config_version, apk_version):
-    config_version = config_version.split('.')
-    apk_version = apk_version.split('.')
+    config_version = version_tuple(config_version)
+    apk_version = version_tuple(apk_version)
 
     if len(apk_version) < len(config_version):
         return False  # More specific version requested than available

--- a/wa/framework/workload.py
+++ b/wa/framework/workload.py
@@ -26,7 +26,8 @@ from devlib.utils.android import ApkInfo
 
 from wa.framework.plugin import TargetedPlugin, Parameter
 from wa.framework.resource import (ApkFile, ReventFile,
-                                   File, loose_version_matching)
+                                   File, loose_version_matching,
+                                   range_version_matching)
 from wa.framework.exception import WorkloadError, ConfigError
 from wa.utils.types import ParameterDict, list_or_string, version_tuple
 from wa.utils.revent import ReventRecorder
@@ -206,6 +207,16 @@ class ApkWorkload(Workload):
                   description="""
                   The version of the package to be used.
                   """),
+        Parameter('max_version', kind=str,
+                  default=None,
+                  description="""
+                  The maximum version of the package to be used.
+                  """),
+        Parameter('min_version', kind=str,
+                  default=None,
+                  description="""
+                  The minimum version of the package to be used.
+                  """),
         Parameter('variant', kind=str,
                   default=None,
                   description="""
@@ -280,7 +291,15 @@ class ApkWorkload(Workload):
                                   exact_abi=self.exact_abi,
                                   prefer_host_package=self.prefer_host_package,
                                   clear_data_on_reset=self.clear_data_on_reset,
-                                  activity=self.activity)
+                                  activity=self.activity,
+                                  min_version=self.min_version,
+                                  max_version=self.max_version)
+
+    def validate(self):
+        if self.min_version and self.max_version:
+            if version_tuple(self.min_version) > version_tuple(self.max_version):
+                msg = 'Cannot specify min version ({}) greater than max version ({})'
+                raise ConfigError(msg.format(self.min_version, self.max_version))
 
     @once_per_instance
     def initialize(self, context):
@@ -669,12 +688,14 @@ class PackageHandler(object):
     def __init__(self, owner, install_timeout=300, version=None, variant=None,
                  package_name=None, strict=False, force_install=False, uninstall=False,
                  exact_abi=False, prefer_host_package=True, clear_data_on_reset=True,
-                 activity=None):
+                 activity=None, min_version=None, max_version=None):
         self.logger = logging.getLogger('apk')
         self.owner = owner
         self.target = self.owner.target
         self.install_timeout = install_timeout
         self.version = version
+        self.min_version = min_version
+        self.max_version = max_version
         self.variant = variant
         self.package_name = package_name
         self.strict = strict
@@ -741,7 +762,9 @@ class PackageHandler(object):
                                                          version=self.version,
                                                          package=self.package_name,
                                                          exact_abi=self.exact_abi,
-                                                         supported_abi=self.supported_abi),
+                                                         supported_abi=self.supported_abi,
+                                                         min_version=self.min_version,
+                                                         max_version=self.max_version),
                                                  strict=self.strict)
         else:
             available_packages = []
@@ -751,7 +774,9 @@ class PackageHandler(object):
                                                         version=self.version,
                                                         package=package,
                                                         exact_abi=self.exact_abi,
-                                                        supported_abi=self.supported_abi),
+                                                        supported_abi=self.supported_abi,
+                                                        min_version=self.min_version,
+                                                        max_version=self.max_version),
                                                 strict=self.strict)
                 if apk_file:
                     available_packages.append(apk_file)
@@ -772,12 +797,17 @@ class PackageHandler(object):
                 if self.target.package_is_installed(package):
                     installed_versions.append(package)
 
-            if self.version:
+            if self.version or self.min_version or self.max_version:
                 matching_packages = []
                 for package in installed_versions:
                     package_version = self.target.get_package_version(package)
-                    for v in list_or_string(self.version):
-                        if loose_version_matching(v, package_version):
+                    if self.version:
+                        for v in list_or_string(self.version):
+                            if loose_version_matching(v, package_version):
+                                matching_packages.append(package)
+                    else:
+                        if range_version_matching(package_version, self.min_version,
+                                                  self.max_version):
                             matching_packages.append(package)
                 if len(matching_packages) == 1:
                     self.package_name = matching_packages[0]

--- a/wa/framework/workload.py
+++ b/wa/framework/workload.py
@@ -389,7 +389,6 @@ class ApkReventWorkload(ApkUIWorkload):
 
     def __init__(self, target, **kwargs):
         super(ApkReventWorkload, self).__init__(target, **kwargs)
-        self.apk = PackageHandler(self)
         self.gui = ReventGUI(self, target,
                              self.setup_timeout,
                              self.run_timeout,

--- a/wa/framework/workload.py
+++ b/wa/framework/workload.py
@@ -28,7 +28,7 @@ from wa.framework.plugin import TargetedPlugin, Parameter
 from wa.framework.resource import (ApkFile, ReventFile,
                                    File, loose_version_matching)
 from wa.framework.exception import WorkloadError, ConfigError
-from wa.utils.types import ParameterDict, list_or_string
+from wa.utils.types import ParameterDict, list_or_string, version_tuple
 from wa.utils.revent import ReventRecorder
 from wa.utils.exec_control import once_per_instance
 

--- a/wa/utils/types.py
+++ b/wa/utils/types.py
@@ -170,9 +170,9 @@ def list_or_caseless_string(value):
 def list_or(type_):
     """
     Generator for "list or" types. These take either a single value or a list
-    values and return a list of the specfied ``type_`` performing the
+    values and return a list of the specified ``type_`` performing the
     conversion on the value (if a single value is specified) or each of the
-    elemented of the specified list.
+    elements of the specified list.
 
     """
     list_type = list_of(type_)
@@ -288,7 +288,7 @@ class prioritylist(object):
 
         - ``new_element`` the element to be inserted in the prioritylist
         - ``priority`` is the priority of the element which specifies its
-        order withing the List
+        order within the List
         """
         self._add_element(new_element, priority)
 

--- a/wa/utils/types.py
+++ b/wa/utils/types.py
@@ -208,6 +208,13 @@ def regex(value):
         return re.compile(value)
 
 
+def version_tuple(v):
+    """
+    Converts a version string into a tuple of ints that can be used for natural comparison.
+    """
+    return tuple(map(int, (v.split("."))))
+
+
 __counters = defaultdict(int)
 
 

--- a/wa/workloads/geekbench/__init__.py
+++ b/wa/workloads/geekbench/__init__.py
@@ -23,6 +23,7 @@ from collections import defaultdict
 from wa import ApkUiautoWorkload, Parameter
 from wa.framework.exception import ConfigError, WorkloadError
 from wa.utils.misc import capitalize
+from wa.utils.types import version_tuple
 
 
 class Geekbench(ApkUiautoWorkload):
@@ -101,7 +102,7 @@ class Geekbench(ApkUiautoWorkload):
     def update_output(self, context):
         super(Geekbench, self).update_output(context)
         if not self.disable_update_result:
-            major_version = versiontuple(self.version)[0]
+            major_version = version_tuple(self.version)[0]
             update_method = getattr(self, 'update_result_{}'.format(major_version))
             update_method(context)
 
@@ -367,7 +368,3 @@ class GeekbenchCorproate(Geekbench):  # pylint: disable=too-many-ancestors
 
 def namemify(basename, i):
     return basename + (' {}'.format(i) if i else '')
-
-
-def versiontuple(v):
-    return tuple(map(int, (v.split("."))))


### PR DESCRIPTION
As per https://github.com/ARM-software/workload-automation/issues/627 WA2 supported specifying not only a particular version of an apk but also a maximum and minimum. Add the corresponding functionality to WA3 and also improve the existing version matching. 