### PR TITLE
Support checking of the default encoding

### DIFF
--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -114,3 +114,10 @@ parameter and will be picked up be the ``fps`` augmentation.
 mismatch of your WA and devlib versions. Please update both to their latest
 versions and delete your ``$USER_HOME/.workload_automation/cache/targets.json``
 (or equivalent) file.
+
+**Q:** I get an error which looks similar to ``UnicodeDecodeError('ascii' codec can't decode byte...``
+-----------------------------------------------------------------------------------------------------
+**A:** If you receive this error or a similar warning about your environment,
+please ensure that you configure your environment to use a locale which supports
+UTF-8. Otherwise this can cause issues when attempting to parse files containing
+none ascii characters.

--- a/extras/Dockerfile
+++ b/extras/Dockerfile
@@ -47,8 +47,14 @@ ARG WA_REF=v3.1.3
 ARG ANDROID_SDK_URL=https://dl.google.com/android/repository/sdk-tools-linux-3859397.zip
 
 RUN apt-get update
-RUN apt-get install -y python3 python3-pip git wget zip openjdk-8-jre-headless vim emacs nano curl sshpass ssh usbutils
+RUN apt-get install -y python3 python3-pip git wget zip openjdk-8-jre-headless vim emacs nano curl sshpass ssh usbutils locales
 RUN pip3 install pandas
+
+# Ensure we're using utf-8 as our default encoding
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
 
 # Let's get the two repos we need, and install them
 RUN git clone -v https://github.com/ARM-software/devlib.git /tmp/devlib && cd /tmp/devlib && git checkout $DEVLIB_REF && python3 setup.py install && pip3 install .[full]

--- a/wa/framework/entrypoint.py
+++ b/wa/framework/entrypoint.py
@@ -16,6 +16,7 @@
 
 import sys
 import argparse
+import locale
 import logging
 import os
 import warnings
@@ -76,6 +77,18 @@ def check_devlib_version():
         raise HostError(msg.format(format_version(required_devlib_version), devlib.__version__))
 
 
+# If the default encoding is not UTF-8 warn the user as this may cause compatibility issues
+# when parsing files.
+def check_system_encoding():
+    system_encoding = locale.getpreferredencoding()
+    msg = 'System Encoding: {}'.format(system_encoding)
+    if 'UTF-8' not in system_encoding:
+        logger.warning(msg)
+        logger.warning('To prevent encoding issues please use a locale setting which supports UTF-8')
+    else:
+        logger.debug(msg)
+
+
 def main():
     if not os.path.exists(settings.user_directory):
         init_user_directory()
@@ -115,6 +128,7 @@ def main():
         logger.debug('devlib version: {}'.format(devlib.__full_version__))
         logger.debug('Command Line: {}'.format(' '.join(sys.argv)))
         check_devlib_version()
+        check_system_encoding()
 
         # each command will add its own subparser
         subparsers = parser.add_subparsers(dest='command')


### PR DESCRIPTION
Motivating https://github.com/ARM-software/workload-automation/issues/982 we want to try and prevent encoding issues during operation therefore provide information to the user if their environment is not configured to support UTF-8. 