### PR TITLE
Storing directories as Artifacts + Postgres Fixes

### DIFF
--- a/doc/source/api/output.rst
+++ b/doc/source/api/output.rst
@@ -315,9 +315,12 @@ methods
 
 .. method:: RunDatabaseOutput.get_artifact_path(name)
 
-    Returns a `StringIO` object containing the contents of the artifact
-    specified by ``name``. This will only look at the run artifacts; this will
-    not search the artifacts of the individual jobs.
+    If the artifcat is a file this method returns a `StringIO` object containing
+    the contents of the artifact specified by ``name``. If the aritifcat is a
+    directory, the method returns a path to a locally extracted version of the
+    directory which is left to the user to remove after use. This will only look
+    at the run artifacts; this will not search the artifacts of the individual
+    jobs.
 
     :param name:  The name of the artifact who's path to retrieve.
     :return: A `StringIO` object with the contents of the artifact
@@ -452,8 +455,11 @@ methods
 
 .. method:: JobDatabaseOutput.get_artifact_path(name)
 
-    Returns a ``StringIO`` object containing the contents of the artifact
-    specified by ``name`` associated with this job.
+    If the artifcat is a file this method returns a `StringIO` object containing
+    the contents of the artifact specified by ``name`` associated with this job.
+    If the aritifcat is a directory, the method returns a path to a locally
+    extracted version of the directory which is left to the user to remove after
+    use.
 
     :param name:  The name of the artifact who's path to retrieve.
     :return: A `StringIO` object with the contents of the artifact

--- a/wa/commands/postgres_schemas/postgres_schema.sql
+++ b/wa/commands/postgres_schemas/postgres_schema.sql
@@ -1,4 +1,4 @@
---!VERSION!1.2!ENDVERSION!
+--!VERSION!1.3!ENDVERSION!
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 CREATE EXTENSION IF NOT EXISTS "lo";
 
@@ -96,6 +96,7 @@ CREATE TABLE Targets (
     android_id text,
     _pod_version int,
     _pod_serialization_version int,
+    system_id text,
     PRIMARY KEY (oid)
 );
 
@@ -164,6 +165,7 @@ CREATE TABLE Artifacts (
     kind text,
     _pod_version int,
     _pod_serialization_version int,
+    is_dir boolean,
     PRIMARY KEY (oid)
 );
 

--- a/wa/commands/postgres_schemas/postgres_schema_update_v1.3.sql
+++ b/wa/commands/postgres_schemas/postgres_schema_update_v1.3.sql
@@ -1,0 +1,3 @@
+ALTER TABLE targets ADD COLUMN system_id text;
+
+ALTER TABLE artifacts ADD COLUMN is_dir boolean;

--- a/wa/commands/schema_changelog.rst
+++ b/wa/commands/schema_changelog.rst
@@ -7,3 +7,13 @@
   was done following an extended discussion and tests that verified
   that the savings in processing power were not enough to warrant
   the creation of a dedicated server or file handler.
+## 1.2
+- Rename the `resourcegetters` table to `resource_getters` for consistency.
+- Add Job and Run level classifiers.
+- Add missing android specific properties to targets.
+- Add new POD meta data to relevant tables. 
+- Correct job column name from `retires` to `retry`.
+- Add missing run information.
+## 1.3
+- Add missing "system_id" field from TargetInfo.
+- Enable support for uploading Artifact that represent directories.

--- a/wa/framework/output.py
+++ b/wa/framework/output.py
@@ -930,8 +930,10 @@ class DatabaseOutput(Output):
         tables = ['largeobjects', 'artifacts']
         joins = [('classifiers', 'classifiers.artifact_oid = artifacts.oid')]
         conditions = ['artifacts.{}_oid = \'{}\''.format(self.kind, self.oid),
-                      'artifacts.large_object_uuid = largeobjects.oid',
-                      'artifacts.job_oid IS NULL']
+                      'artifacts.large_object_uuid = largeobjects.oid']
+        # If retrieving run level artifacts we want those that don't also belong to a job
+        if self.kind == 'run':
+            conditions.append('artifacts.job_oid IS NULL')
         pod = self._read_db(columns, tables, conditions, joins)
         for artifact in pod:
             artifact['path'] = str(artifact['path'])

--- a/wa/framework/output.py
+++ b/wa/framework/output.py
@@ -948,8 +948,9 @@ class DatabaseOutput(Output):
 
 def kernel_config_from_db(raw):
     kernel_config = {}
-    for k, v in zip(raw[0], raw[1]):
-        kernel_config[k] = v
+    if raw:
+        for k, v in zip(raw[0], raw[1]):
+            kernel_config[k] = v
     return kernel_config
 
 

--- a/wa/framework/output.py
+++ b/wa/framework/output.py
@@ -968,7 +968,8 @@ class RunDatabaseOutput(DatabaseOutput, RunOutputCommon):
     def _db_targetfile(self):
         columns = ['os', 'is_rooted', 'target', 'abi', 'cpus', 'os_version',
                    'hostid', 'hostname', 'kernel_version', 'kernel_release',
-                   'kernel_sha1', 'kernel_config', 'sched_features',
+                   'kernel_sha1', 'kernel_config', 'sched_features', 'page_size_kb',
+                   'system_id', 'screen_resolution', 'prop', 'android_id',
                    '_pod_version', '_pod_serialization_version']
         tables = ['targets']
         conditions = ['targets.run_oid = \'{}\''.format(self.oid)]

--- a/wa/instruments/misc.py
+++ b/wa/instruments/misc.py
@@ -174,8 +174,14 @@ class SysfsExtractor(Instrument):
                     self.target.list_directory(dev_dir)):
                 self.logger.error('sysfs files were not pulled from the device.')
                 self.device_and_host_paths.remove(paths)  # Path is removed to skip diffing it
-        for _, before_dir, after_dir, diff_dir in self.device_and_host_paths:
+        for dev_dir, before_dir, after_dir, diff_dir in self.device_and_host_paths:
             diff_sysfs_dirs(before_dir, after_dir, diff_dir)
+            context.add_artifact('{} [before]'.format(dev_dir), before_dir,
+                                 kind='data', classifiers={'stage': 'before'})
+            context.add_artifact('{} [after]'.format(dev_dir), after_dir,
+                                 kind='data', classifiers={'stage': 'after'})
+            context.add_artifact('{} [diff]'.format(dev_dir), diff_dir,
+                                 kind='data', classifiers={'stage': 'diff'})
 
     def teardown(self, context):
         self._one_time_setup_done = []

--- a/wa/instruments/misc.py
+++ b/wa/instruments/misc.py
@@ -276,9 +276,15 @@ class InterruptStatsInstrument(Instrument):
             wfh.write(self.target.execute('cat /proc/interrupts'))
 
     def update_output(self, context):
+        context.add_artifact('interrupts [before]', self.before_file, kind='data',
+                             classifiers={'stage': 'before'})
         # If workload execution failed, the after_file may not have been created.
         if os.path.isfile(self.after_file):
             diff_interrupt_files(self.before_file, self.after_file, _f(self.diff_file))
+            context.add_artifact('interrupts [after]', self.after_file, kind='data',
+                                 classifiers={'stage': 'after'})
+            context.add_artifact('interrupts [diff]', self.diff_file, kind='data',
+                                 classifiers={'stage': 'diff'})
 
 
 class DynamicFrequencyInstrument(SysfsExtractor):

--- a/wa/output_processors/postgresql.py
+++ b/wa/output_processors/postgresql.py
@@ -209,8 +209,8 @@ class PostgresqlResultProcessor(OutputProcessor):
                 list(target_pod.get('screen_resolution', [])),
                 target_pod.get('prop'),
                 target_pod.get('android_id'),
-                target_pod.get('pod_version'),
-                target_pod.get('pod_serialization_version'),
+                target_pod.get('_pod_version'),
+                target_pod.get('_pod_serialization_version'),
             )
         )
 

--- a/wa/output_processors/postgresql.py
+++ b/wa/output_processors/postgresql.py
@@ -24,6 +24,7 @@ try:
 except ImportError as e:
     psycopg2 = None
     import_error_msg = e.args[0] if e.args else str(e)
+
 from devlib.target import KernelVersion, KernelConfig
 
 from wa import OutputProcessor, Parameter, OutputProcessorError
@@ -88,8 +89,8 @@ class PostgresqlResultProcessor(OutputProcessor):
                       "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
         "update_run": "UPDATE Runs SET event_summary=%s, status=%s, timestamp=%s, end_time=%s, duration=%s, state=%s WHERE oid=%s;",
         "create_job": "INSERT INTO Jobs (oid, run_oid, status, retry, label, job_id, iterations, workload_name, metadata, _pod_version, _pod_serialization_version) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s);",
-        "create_target": "INSERT INTO Targets (oid, run_oid, target, cpus, os, os_version, hostid, hostname, abi, is_rooted, kernel_version, kernel_release, kernel_sha1, kernel_config, sched_features, page_size_kb, screen_resolution, prop, android_id, _pod_version, _pod_serialization_version) "
-                         "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
+        "create_target": "INSERT INTO Targets (oid, run_oid, target, cpus, os, os_version, hostid, hostname, abi, is_rooted, kernel_version, kernel_release, kernel_sha1, kernel_config, sched_features, page_size_kb, system_id, screen_resolution, prop, android_id, _pod_version, _pod_serialization_version) "
+                         "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
         "create_event": "INSERT INTO Events (oid, run_oid, job_oid, timestamp, message, _pod_version, _pod_serialization_version) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s",
         "create_artifact": "INSERT INTO Artifacts (oid, run_oid, job_oid, name, large_object_uuid, description, kind, _pod_version, _pod_serialization_version) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)",
         "create_metric": "INSERT INTO Metrics (oid, run_oid, job_oid, name, value, units, lower_is_better, _pod_version, _pod_serialization_version) VALUES (%s, %s, %s, %s, %s, %s , %s, %s, %s)",
@@ -205,6 +206,7 @@ class PostgresqlResultProcessor(OutputProcessor):
                 target_info.kernel_config,
                 target_pod['sched_features'],
                 target_pod['page_size_kb'],
+                target_pod['system_id'],
                 # Android Specific
                 list(target_pod.get('screen_resolution', [])),
                 target_pod.get('prop'),

--- a/wa/utils/postgres.py
+++ b/wa/utils/postgres.py
@@ -199,7 +199,6 @@ def create_iterable_adapter(array_columns, explicit_iterate=False):
                     array_string = "{" + array_string + "}"
                     final_string = final_string + array_string + ","
                 final_string = final_string.strip(",")
-                final_string = "{" + final_string + "}"
             else:
                 # Simply return each item in the array
                 if explicit_iterate:
@@ -208,8 +207,7 @@ def create_iterable_adapter(array_columns, explicit_iterate=False):
                 else:
                     for item in param:
                         final_string = final_string + str(item) + ","
-                final_string = "{" + final_string + "}"
-        return AsIs("'{}'".format(final_string))
+        return AsIs("'{{{}}}'".format(final_string))
     return adapt_iterable
 
 

--- a/wa/utils/postgres.py
+++ b/wa/utils/postgres.py
@@ -243,10 +243,10 @@ def get_schema(schemafilepath):
 def get_database_schema_version(conn):
     with conn.cursor() as cursor:
         cursor.execute('''SELECT
-                                  DatabaseMeta.schema_major,
-                                  DatabaseMeta.schema_minor
-                               FROM
-                                  DatabaseMeta;''')
+                              DatabaseMeta.schema_major,
+                              DatabaseMeta.schema_minor
+                          FROM
+                              DatabaseMeta;''')
         schema_major, schema_minor = cursor.fetchone()
     return (schema_major, schema_minor)
 


### PR DESCRIPTION
This set of commits allows for storing directories as an Artifact and implements the functionality of being transparently uploaded and retrieved from a database.

Items to note:
- Upon uploading artifacts to the database the directory will be compressed and stored as a `.tar.gz` file.
- Upon invocation of `get_artifact_path` the `.tar.gz` file will be streamed from the database and  extracted to a temporary location with the prefix `'wa_'` before returning the path of the newly extracted directory. It is currently left to the user to delete the folder once they are finished with it. 
- The naming scheme for the `SysfsExtractor` instrument artifacts is currently in the form `<path> [stage]` for example `/sys/devices/system/cpu [before]`.