### PR TITLE
Add ReadTheDocs configuration file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,21 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  builder: html
+  configuration: doc/source/conf.py
+
+# Build the docs in additional formats such as PDF and ePub
+formats: all
+
+# Set the version of Python and requirements required to build your docs
+python:
+   version: 3.7
+   install:
+      - method: setuptools
+        path: .


### PR DESCRIPTION
Provide configuration file for building the documentation. We need to
specify to use python3 explicitly.