### PR TITLE
setup.py: Update pandas version restrictions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,8 +93,8 @@ params = dict(
         'devlib>={}'.format(devlib_version),  # Interacting with devices
         'louie-latest',  # callbacks dispatch
         'wrapt',  # better decorators
-        'pandas>=0.23.0,<=0.24.2; python_version<"3"',  # Data analysis and manipulation
-        'pandas>=0.23.0; python_version>"3"',  # Data analysis and manipulation
+        'pandas>=0.23.0,<=0.24.2; python_version<"3.5.3"',  # Data analysis and manipulation
+        'pandas>=0.23.0; python_version>="3.5.3"',  # Data analysis and manipulation
         'future',  # Python 2-3 compatiblity
     ],
     dependency_links=['https://github.com/ARM-software/devlib/tarball/master#egg=devlib-{}'.format(devlib_version)],


### PR DESCRIPTION
Pandas versions 0.25+ requires Python 3.5.3 as a minimum so ensure that
an older version of pandas is installed for older versions of Python.
