### PR TITLE
instrument/energy_measurement: Invoke teardown method for backends

### DIFF
--- a/wa/instruments/energy_measurement.py
+++ b/wa/instruments/energy_measurement.py
@@ -510,3 +510,7 @@ class EnergyMeasurement(Instrument):
                 units = metrics[0].units
                 value = sum(m.value for m in metrics)
                 context.add_metric(name, value, units)
+
+    def teardown(self, context):
+        for instrument in self.instruments.values():
+            instrument.teardown()


### PR DESCRIPTION
Forward the teardown method invocation to the instrument backend.

Related to https://github.com/ARM-software/devlib/pull/431