### PR TITLE
Postgres OutputProcessor Fixes

### DIFF
--- a/wa/commands/postgres_schemas/postgres_schema.sql
+++ b/wa/commands/postgres_schemas/postgres_schema.sql
@@ -1,4 +1,4 @@
---!VERSION!1.4!ENDVERSION!
+--!VERSION!1.5!ENDVERSION!
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 CREATE EXTENSION IF NOT EXISTS "lo";
 
@@ -82,7 +82,7 @@ CREATE TABLE Targets (
     cpus text[],
     os text,
     os_version jsonb,
-    hostid int,
+    hostid bigint,
     hostname text,
     abi text,
     is_rooted boolean,

--- a/wa/commands/postgres_schemas/postgres_schema_update_v1.5.sql
+++ b/wa/commands/postgres_schemas/postgres_schema_update_v1.5.sql
@@ -1,0 +1,1 @@
+ALTER TABLE targets ALTER hostid TYPE BIGINT;

--- a/wa/commands/schema_changelog.rst
+++ b/wa/commands/schema_changelog.rst
@@ -17,3 +17,8 @@
 ## 1.3
 - Add missing "system_id" field from TargetInfo.
 - Enable support for uploading Artifact that represent directories.
+## 1.4
+- Add "modules" field to TargetInfo to list the modules loaded by the target
+  during the run.
+## 1.5
+- Change the type of the "hostid" in TargetInfo from Int to Bigint.

--- a/wa/framework/target/info.py
+++ b/wa/framework/target/info.py
@@ -421,3 +421,4 @@ class TargetInfo(Podable):
     @staticmethod
     def _pod_upgrade_v5(pod):
         pod['modules'] = pod.get('modules') or []
+        return pod


### PR DESCRIPTION
- Fix upgrade of `TargetInfo` POD to v5.
- Change "hostid" field to Bigint to allow storing of larger ids. 