### PR TITLE
fw/job: copy classifiers from the spec

### DIFF
--- a/wa/framework/job.py
+++ b/wa/framework/job.py
@@ -38,10 +38,6 @@ class Job(object):
         return self.spec.label
 
     @property
-    def classifiers(self):
-        return self.spec.classifiers
-
-    @property
     def status(self):
         return self._status
 
@@ -64,6 +60,7 @@ class Job(object):
         self.output = None
         self.run_time = None
         self.retries = 0
+        self.classifiers = copy(self.spec.classifiers)
         self._has_been_initialized = False
         self._status = Status.NEW
 


### PR DESCRIPTION
Now that classifiers may be added to the job during execution, its
classifiers dict should be unique to each job rather than just returning
them form spec (which may be shared between multiple jobs.)