### PR TITLE
workloads/exoplayer: Support Android 10

### DIFF
--- a/wa/workloads/exoplayer/__init__.py
+++ b/wa/workloads/exoplayer/__init__.py
@@ -36,7 +36,7 @@ from devlib.utils.android import grant_app_permissions
 
 # Regexps for benchmark synchronization
 REGEXPS = {
-    'start': '.*Displayed com.google.android.exoplayer2.demo/.PlayerActivity',
+    'start': '.*(Displayed|START).*com.google.android.exoplayer2.demo/.PlayerActivity',
     'duration': '.*period \[(?P<duration>[0-9]+.*)\]',
     'end': '.*state \[.+, .+, E\]',
     'dropped_frames': '.*droppedFrames \[(?P<session_time>[0-9]+\.[0-9]+), (?P<count>[0-9]+)\]'


### PR DESCRIPTION
Android 10 appears to use a new format in logcat when displaying the
PlayerActivity. Update the regex to suport both formats.