### PR TITLE
fw/workload: Prefix `TestPackages` with "test_"

### DIFF
--- a/wa/framework/workload.py
+++ b/wa/framework/workload.py
@@ -904,15 +904,19 @@ class PackageHandler(object):
             message = 'Cannot retrieve "{}" as not installed on Target'
             raise WorkloadError(message.format(package))
         package_info = self.target.get_package_info(package)
-        self.target.pull(package_info.apk_path, self.owner.dependencies_directory,
+        apk_name = self._get_package_name(package_info.apk_path)
+        host_path = os.path.join(self.owner.dependencies_directory, apk_name)
+        self.target.pull(package_info.apk_path, host_path,
                          timeout=self.install_timeout)
-        apk_name = self.target.path.basename(package_info.apk_path)
-        return os.path.join(self.owner.dependencies_directory, apk_name)
+        return host_path
 
     def teardown(self):
         self.target.execute('am force-stop {}'.format(self.apk_info.package))
         if self.uninstall:
             self.target.uninstall_package(self.apk_info.package)
+
+    def _get_package_name(self, apk_path):
+        return self.target.path.basename(apk_path)
 
     def _get_package_error_msg(self, location):
         if self.version:
@@ -980,6 +984,9 @@ class TestPackageHandler(PackageHandler):
     def _start_instrument(self):
         self._instrument_output = self.target.execute(self.cmd)
         self.logger.debug(self._instrument_output)
+
+    def _get_package_name(self, apk_path):
+        return 'test_{}'.format(self.target.path.basename(apk_path))
 
     @property
     def instrument_output(self):


### PR DESCRIPTION
Previously, when pulling an apk from the target to the host, the default
package name was used for both regular apks and test apks. This could
result in one package overwriting the other. To prevent this ensure
`TestPackages` have the "test_" prefixed to their filename.