### PR TITLE
fw/plugin: move cleanup_assets to TargetedPlugin

### DIFF
--- a/wa/framework/plugin.py
+++ b/wa/framework/plugin.py
@@ -384,6 +384,16 @@ class TargetedPlugin(Plugin):
     """
 
     suppoted_targets = []
+    parameters = [
+        Parameter('cleanup_assets', kind=bool,
+                  global_alias='cleanup_assets',
+                  aliases=['clean_up'],
+                  default=True,
+                  description="""
+                  If ``True``, assets that are deployed or created by the
+                  plugin will be removed again from the device.
+                  """),
+    ]
 
     @classmethod
     def check_compatible(cls, target):

--- a/wa/framework/workload.py
+++ b/wa/framework/workload.py
@@ -44,14 +44,6 @@ class Workload(TargetedPlugin):
     kind = 'workload'
 
     parameters = [
-        Parameter('cleanup_assets', kind=bool,
-                  global_alias='cleanup_assets',
-                  aliases=['clean_up'],
-                  default=True,
-                  description="""
-                  If ``True``, assets that are deployed or created as part of the
-                  workload will be removed again from the device.
-                  """),
         Parameter('uninstall', kind=bool,
                   default=True,
                   description="""


### PR DESCRIPTION
Move cleanup_assets from Workload up into TargetedPlugin. This way,
Instruments may also utilize it if they deploy assets.

More generally, it makes sense for it to be inside TargetedPlugin, as
any plugin that interacts with the target may conceivably need to clean
up.