### PR TITLE
utils/types: fix toggle_set creation

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -190,3 +190,10 @@ class  TestToggleSet(TestCase):
 
         ts6 = ts2.merge_into(ts3).merge_with(ts1)
         assert_equal(ts6, toggle_set(['one', 'two', 'three', 'four', 'five', '~~']))
+
+    def test_order_on_create(self):
+        ts1 = toggle_set(['one', 'two', 'three', '~one'])
+        assert_equal(ts1, toggle_set(['~one', 'two', 'three']))
+
+        ts1 = toggle_set(['~one', 'two', 'three', 'one'])
+        assert_equal(ts1, toggle_set(['one', 'two', 'three']))

--- a/wa/utils/types.py
+++ b/wa/utils/types.py
@@ -432,6 +432,14 @@ class toggle_set(set):
             if isinstance(value, str):
                 msg = 'invalid type for toggle_set: "{}"'
                 raise TypeError(msg.format(type(value)))
+            updated_value = []
+            for v in value:
+                if v.startswith('~') and v[1:] in updated_value:
+                    updated_value.remove(v[1:])
+                elif not v.startswith('~') and ('~' + v) in updated_value:
+                    updated_value.remove(('~' + v))
+                updated_value.append(v)
+            args = tuple([updated_value] + list(args[1:]))
         set.__init__(self, *args)
 
     def merge_with(self, other):


### PR DESCRIPTION
Correctly handle the presence of both an element and its toggle in the
input, and handle them base on order, e.g.

toggle_set(['x', 'y', '~x']) --> {'y', '~x'}
toggle_set(['~x', 'y', 'x']) --> {'y', 'x'}