### PR TITLE
target/descriptor: Make `strict_host_check` default to `False`

### DIFF
--- a/wa/framework/target/descriptor.py
+++ b/wa/framework/target/descriptor.py
@@ -333,7 +333,7 @@ CONNECTION_PARAMS = {
             The port SSH server is listening on on the target.
             """),
         Parameter(
-            'strict_host_check', kind=bool, default=True,
+            'strict_host_check', kind=bool, default=False,
             description="""
             Specify whether devices should be connected to if
             their host key does not match the systems known host keys. """),


### PR DESCRIPTION
The majority of users will not find a benefit of the additional
check so make this parameter default to `False` instead.