### PR TITLE
logcat_parsing: Replace errors when decoding logcat output

### DIFF
--- a/wa/utils/android.py
+++ b/wa/utils/android.py
@@ -51,7 +51,7 @@ class LogcatEvent(object):
 class LogcatParser(object):
 
     def parse(self, filepath):
-        with open(filepath) as fh:
+        with open(filepath, errors='replace') as fh:
             for line in fh:
                 event = self.parse_line(line)
                 if event:

--- a/wa/workloads/aitutu/__init__.py
+++ b/wa/workloads/aitutu/__init__.py
@@ -50,7 +50,7 @@ class Aitutu(ApkUiautoWorkload):
         super(Aitutu, self).update_output(context)
         expected_results = len(self.regex_matches)
         logcat_file = context.get_artifact_path('logcat')
-        with open(logcat_file) as fh:
+        with open(logcat_file, errors='replace') as fh:
             for line in fh:
                 for regex in self.regex_matches:
                     match = regex.search(line)

--- a/wa/workloads/androbench/__init__.py
+++ b/wa/workloads/androbench/__init__.py
@@ -43,7 +43,7 @@ class Androbench(ApkUiautoWorkload):
         super(Androbench, self).update_output(context)
         expected_results = len(self.regex_matches)
         logcat_file = context.get_artifact_path('logcat')
-        with open(logcat_file) as fh:
+        with open(logcat_file, errors='replace') as fh:
             for line in fh:
                 for regex in self.regex_matches:
                     match = regex.search(line)

--- a/wa/workloads/antutu/__init__.py
+++ b/wa/workloads/antutu/__init__.py
@@ -77,7 +77,7 @@ class Antutu(ApkUiautoWorkload):
         #pylint: disable=no-self-use
         expected_results = len(regex_version)
         logcat_file = context.get_artifact_path('logcat')
-        with open(logcat_file) as fh:
+        with open(logcat_file, errors='replace') as fh:
             for line in fh:
                 for regex in regex_version:
                     match = regex.search(line)

--- a/wa/workloads/benchmarkpi/__init__.py
+++ b/wa/workloads/benchmarkpi/__init__.py
@@ -51,7 +51,7 @@ class BenchmarkPi(ApkUiautoWorkload):
     def update_output(self, context):
         super(BenchmarkPi, self).update_output(context)
         logcat_file = context.get_artifact_path('logcat')
-        with open(logcat_file) as fh:
+        with open(logcat_file, errors='replace') as fh:
             for line in fh:
                 match = self.regex.search(line)
                 if match:

--- a/wa/workloads/gfxbench/__init__.py
+++ b/wa/workloads/gfxbench/__init__.py
@@ -51,7 +51,7 @@ class Gfxbench(ApkUiautoWorkload):
         super(Gfxbench, self).update_output(context)
         expected_results = len(self.regex_matches)
         logcat_file = context.get_artifact_path('logcat')
-        with open(logcat_file) as fh:
+        with open(logcat_file, errors='replace') as fh:
             for line in fh:
                 for regex in self.regex_matches:
                     match = regex.search(line)

--- a/wa/workloads/jankbench/__init__.py
+++ b/wa/workloads/jankbench/__init__.py
@@ -153,7 +153,7 @@ class Jankbench(ApkWorkload):
     def extract_metrics_from_logcat(self, context):
         metric_names = ['mean', 'junk_p', 'std_dev', 'count_bad', 'count_junk']
         logcat_file = context.get_artifact_path('logcat')
-        with open(logcat_file) as fh:
+        with open(logcat_file, errors='replace') as fh:
             run_tests = copy(self.test_ids or self.valid_test_ids)
             current_iter = None
             current_test = None

--- a/wa/workloads/motionmark/__init__.py
+++ b/wa/workloads/motionmark/__init__.py
@@ -61,7 +61,7 @@ class Motionmark(UiautoWorkload):
         super(Motionmark, self).update_output(context)
         num_unprocessed_results = len(self.regex)
         logcat_file = context.get_artifact_path('logcat')
-        with open(logcat_file) as fh:
+        with open(logcat_file, errors='replace') as fh:
             for line in fh:
                 for regex in self.regex:
                     match = regex.search(line)

--- a/wa/workloads/speedometer/__init__.py
+++ b/wa/workloads/speedometer/__init__.py
@@ -20,6 +20,7 @@ from wa.framework.exception import ValidationError, WorkloadError
 from wa.utils.types import list_of_strs
 from wa.utils.misc import unique
 
+
 class Speedometer(ApkUiautoWorkload):
 
     name = 'speedometer'
@@ -55,7 +56,7 @@ class Speedometer(ApkUiautoWorkload):
         super(Speedometer, self).update_output(context)
         result = None
         logcat_file = context.get_artifact_path('logcat')
-        with open(logcat_file) as fh:
+        with open(logcat_file, errors='replace') as fh:
             for line in fh:
                 match = self.regex.search(line)
                 if match:
@@ -65,4 +66,3 @@ class Speedometer(ApkUiautoWorkload):
             context.add_metric('Speedometer Score', result, 'Runs per minute', lower_is_better=False)
         else:
             raise WorkloadError("The Speedometer workload has failed. No score was obtainable.")
-

--- a/wa/workloads/vellamo/__init__.py
+++ b/wa/workloads/vellamo/__init__.py
@@ -145,7 +145,7 @@ class Vellamo(ApkUiautoWorkload):
     def non_root_update_output(self, context):
         failed = []
         logcat_file = context.get_artifact_path('logcat')
-        with open(logcat_file) as fh:
+        with open(logcat_file, errors='replace') as fh:
             iteration_result_regex = re.compile("VELLAMO RESULT: (Browser|Metal|Multicore) (\d+)")
             for line in fh:
                 if 'VELLAMO ERROR:' in line:


### PR DESCRIPTION
Some devices print non standard characters to logcat. If an error
occurs when parsing the output, replace the offending character instead
of raising an error.