### PR TITLE
Implement caching of local ApkInfo Objects 

### DIFF
--- a/wa/framework/configuration/core.py
+++ b/wa/framework/configuration/core.py
@@ -537,6 +537,10 @@ class MetaConfiguration(Configuration):
     def target_info_cache_file(self):
         return os.path.join(self.cache_directory, 'targets.json')
 
+    @property
+    def apk_info_cache_file(self):
+        return os.path.join(self.cache_directory, 'apk_info.json')
+
     def __init__(self, environ=None):
         super(MetaConfiguration, self).__init__()
         if environ is None:

--- a/wa/framework/resource.py
+++ b/wa/framework/resource.py
@@ -16,16 +16,14 @@ import logging
 import os
 import re
 
-from devlib.utils.android import ApkInfo
-
 from wa.framework import pluginloader
 from wa.framework.plugin import Plugin
 from wa.framework.exception import ResourceError
 from wa.framework.configuration import settings
 from wa.utils import log
+from wa.utils.android import get_cacheable_apk_info
 from wa.utils.misc import get_object_name
 from wa.utils.types import enum, list_or_string, prioritylist, version_tuple
-from wa.utils.misc import lock_file
 
 
 SourcePriority = enum(['package', 'remote', 'lan', 'local',
@@ -281,8 +279,7 @@ class ResourceResolver(object):
 
 def apk_version_matches(path, version):
     version = list_or_string(version)
-    with lock_file(path):
-        info = ApkInfo(path)
+    info = get_cacheable_apk_info(path)
     for v in version:
         if info.version_name == v or info.version_code == v:
             return True
@@ -292,8 +289,7 @@ def apk_version_matches(path, version):
 
 
 def apk_version_matches_range(path, min_version=None, max_version=None):
-    with lock_file(path):
-        info = ApkInfo(path)
+    info = get_cacheable_apk_info(path)
     return range_version_matching(info.version_name, min_version, max_version)
 
 
@@ -336,21 +332,18 @@ def file_name_matches(path, pattern):
 
 
 def uiauto_test_matches(path, uiauto):
-    with lock_file(path):
-        info = ApkInfo(path)
+    info = get_cacheable_apk_info(path)
     return uiauto == ('com.arm.wa.uiauto' in info.package)
 
 
 def package_name_matches(path, package):
-    with lock_file(path):
-        info = ApkInfo(path)
+    info = get_cacheable_apk_info(path)
     return info.package == package
 
 
 def apk_abi_matches(path, supported_abi, exact_abi=False):
     supported_abi = list_or_string(supported_abi)
-    with lock_file(path):
-        info = ApkInfo(path)
+    info = get_cacheable_apk_info(path)
     # If no native code present, suitable for all devices.
     if not info.native_code:
         return True

--- a/wa/framework/workload.py
+++ b/wa/framework/workload.py
@@ -22,8 +22,8 @@ try:
 except ImportError:
     from pipes import quote
 
-from devlib.utils.android import ApkInfo
 
+from wa.utils.android import get_cacheable_apk_info
 from wa.framework.plugin import TargetedPlugin, Parameter
 from wa.framework.resource import (ApkFile, ReventFile,
                                    File, loose_version_matching,
@@ -523,7 +523,7 @@ class UiAutomatorGUI(object):
     def init_resources(self, resolver):
         self.uiauto_file = resolver.get(ApkFile(self.owner, uiauto=True))
         if not self.uiauto_package:
-            uiauto_info = ApkInfo(self.uiauto_file)
+            uiauto_info = get_cacheable_apk_info(self.uiauto_file)
             self.uiauto_package = uiauto_info.package
 
     def init_commands(self):
@@ -743,8 +743,7 @@ class PackageHandler(object):
                     self.resolve_package_from_host(context)
 
             if self.apk_file:
-                with lock_file(self.apk_file):
-                    self.apk_info = ApkInfo(self.apk_file)
+                self.apk_info = get_cacheable_apk_info(self.apk_file)
             else:
                 if self.error_msg:
                     raise WorkloadError(self.error_msg)

--- a/wa/instruments/misc.py
+++ b/wa/instruments/misc.py
@@ -32,16 +32,16 @@ import tarfile
 from subprocess import CalledProcessError
 
 from devlib.exception import TargetError
-from devlib.utils.android import ApkInfo
 
 from wa import Instrument, Parameter, very_fast
 from wa.framework.exception import ConfigError
 from wa.framework.instrument import slow
 from wa.utils.diff import diff_sysfs_dirs, diff_interrupt_files
-from wa.utils.misc import as_relative, lock_file
+from wa.utils.misc import as_relative
 from wa.utils.misc import ensure_file_directory_exists as _f
 from wa.utils.misc import ensure_directory_exists as _d
 from wa.utils.types import list_of_strings
+from wa.utils.android import get_cacheable_apk_info
 
 
 logger = logging.getLogger(__name__)
@@ -244,8 +244,7 @@ class ApkVersion(Instrument):
 
     def setup(self, context):
         if hasattr(context.workload, 'apk_file'):
-            with lock_file(context.workload.apk_file):
-                self.apk_info = ApkInfo(context.workload.apk_file)
+            self.apk_info = get_cacheable_apk_info(context.workload.apk_file)
         else:
             self.apk_info = None
 


### PR DESCRIPTION
To prevent the requirement of locking and parsing an APK file multiple times cache the information using its path and last modified time. This should improve execution times when using large APK files and reduce contention when running with multiple instances of WA. 

Dependent on https://github.com/ARM-software/devlib/pull/488