### PR TITLE
config/core: Fix handling of depreciated parameters

### DIFF
--- a/wa/framework/configuration/core.py
+++ b/wa/framework/configuration/core.py
@@ -290,6 +290,9 @@ class ConfigurationPoint(object):
 
     def set_value(self, obj, value=None, check_mandatory=True):
         if self.deprecated:
+            if value is not None:
+                msg = 'Depreciated parameter supplied for "{}" in "{}". The value will be ignored.'
+                logger.warning(msg.format(self.name, obj.name))
             return
         if value is None:
             if self.default is not None:
@@ -312,11 +315,9 @@ class ConfigurationPoint(object):
         setattr(obj, self.name, value)
 
     def validate(self, obj, check_mandatory=True):
-        value = getattr(obj, self.name, None)
         if self.deprecated:
-            msg = 'Depreciated parameter supplied for "{}" in "{}". The value will be ignored.'
-            logger.warning(msg.format(self.name, obj.name))
             return
+        value = getattr(obj, self.name, None)
         if value is not None:
             self.validate_value(obj.name, value)
         else:


### PR DESCRIPTION
Provide warning to user when attempting to set a depreciated
parameter instead of during validation and only raise the warning
if a value has been explicitly provided.