### PR TITLE
docs/user_information: Fix references to Python 2.7

### DIFF
--- a/doc/source/developer_information/developer_reference/plugins.rst
+++ b/doc/source/developer_information/developer_reference/plugins.rst
@@ -119,7 +119,7 @@ context.output_directory
         This is the output directory for the current iteration. This will an
         iteration-specific subdirectory under the main results location. If
         there is no current iteration (e.g. when processing overall run results)
-        this will point to the same location as ``root_output_directory``.
+        this will point to the same location as ``run_output_directory``.
 
 
 Additionally, the global ``wa.settings`` object exposes on other location:

--- a/doc/source/user_information/installation.rst
+++ b/doc/source/user_information/installation.rst
@@ -73,7 +73,7 @@ the install location of the SDK (i.e. ``<path_to_android_sdk>/sdk``).
 Python
 ------
 
-Workload Automation 3 currently supports both Python 2.7 and Python 3.
+Workload Automation 3 currently supports Python 3.5+
 
 .. _pip:
 
@@ -95,11 +95,11 @@ similar distributions, this may be done with APT::
                   sudo -H pip install --upgrade pip
                   sudo -H pip install --upgrade setuptools
 
-          If you do run  into this issue after already installing some packages,
+          If you do run into this issue after already installing some packages,
           you can resolve it by running ::
 
-                  sudo chmod -R a+r /usr/local/lib/python2.7/dist-packages
-                  sudo find /usr/local/lib/python2.7/dist-packages -type d -exec chmod a+x {} \;
+                  sudo chmod -R a+r /usr/local/lib/python3.X/dist-packages
+                  sudo find /usr/local/lib/python3.X/dist-packages -type d -exec chmod a+x {} \;
 
           (The paths above will work for Ubuntu; they may need to be adjusted
           for other distros).

--- a/doc/source/user_information/user_guide.rst
+++ b/doc/source/user_information/user_guide.rst
@@ -20,7 +20,7 @@ Install
 .. note:: This is a quick summary. For more detailed instructions, please see
           the :ref:`installation` section.
 
-Make sure you have Python 2.7 or Python 3 and a recent Android SDK with API
+Make sure you have Python 3.5+ and a recent Android SDK with API
 level 18 or above installed on your system. A complete install of the Android
 SDK is required, as WA uses a number of its utilities, not just adb. For the
 SDK, make sure that either ``ANDROID_HOME`` environment variable is set, or that

--- a/doc/source/user_information/user_reference/invocation.rst
+++ b/doc/source/user_information/user_reference/invocation.rst
@@ -40,7 +40,7 @@ Will display help for this subcommand that will look something like this:
           AGENDA                Agenda for this workload automation run. This defines
                                 which workloads will be executed, how many times, with
                                 which tunables, etc. See example agendas in
-                                /usr/local/lib/python2.7/dist-packages/wa for an
+                                /usr/local/lib/python3.X/dist-packages/wa for an
                                 example of how this file should be structured.
 
         optional arguments:


### PR DESCRIPTION
- Remove references to Python 2.7 and update example paths
to Python3.
- Fix incorrect attribute name