### PR TITLE
doc: fix callback priority table

### DIFF
--- a/doc/build_instrument_method_map.py
+++ b/doc/build_instrument_method_map.py
@@ -28,8 +28,9 @@ OUTPUT_TEMPLATE_FILE =  os.path.join(os.path.dirname(__file__), 'source', 'instr
 def generate_instrument_method_map(outfile):
     signal_table = format_simple_table([(k, v) for k, v in SIGNAL_MAP.items()],
                                        headers=['method name', 'signal'], align='<<')
-    priority_table = format_simple_table(zip(CallbackPriority.names, CallbackPriority.values),
-                                         headers=['decorator', 'priority'],  align='<>')
+    decorator_names = map(lambda x: x.replace('high', 'fast').replace('low', 'slow'), CallbackPriority.names)
+    priority_table = format_simple_table(zip(decorator_names, CallbackPriority.names, CallbackPriority.values),
+            headers=['decorator', 'CallbackPriority name', 'CallbackPriority value'],  align='<>')
     with open(OUTPUT_TEMPLATE_FILE) as fh:
         template = string.Template(fh.read())
     with open(outfile, 'w') as wfh:

--- a/doc/source/instrument_method_map.template
+++ b/doc/source/instrument_method_map.template
@@ -13,10 +13,11 @@ these signals are dispatched during execution please see the
 $signal_names
 
 The methods above may be decorated with on the listed decorators to set the
-priority of the Instrument method relative to other callbacks registered for the
-signal (within the same priority level, callbacks are invoked in the order they
-were registered). The table below shows the mapping of the decorator to the
-corresponding priority:
+priority (a value in the ``wa.framework.signal.CallbackPriority`` enum) of the
+Instrument method relative to other callbacks registered for the signal (within
+the same priority level, callbacks are invoked in the order they were
+registered). The table below shows the mapping of the decorator to the
+corresponding priority name and level:
 
 $priority_prefixes
 


### PR DESCRIPTION
Correctly specify the decorator name that should be used to give an
instrument method appropriate priority when it's being invoked via
signal dispatch.

Previously, the table was listing the priority enum names in the column
that was labeled "decorator". Now both are shown and the distinction has
been made clearer.