### PR TITLE
WA/Jankbench: Update Pandas function to remove deprecated .ix access

### DIFF
--- a/wa/workloads/jankbench/__init__.py
+++ b/wa/workloads/jankbench/__init__.py
@@ -145,7 +145,7 @@ class Jankbench(ApkWorkload):
             results.columns = ['mean', 'std_dev', 'count_jank', 'jank_p']
 
             for test_name, rep in results.index:
-                test_results = results.ix[test_name, rep]
+                test_results = results.loc[test_name, rep]
                 for metric, value in test_results.items():
                     context.add_metric(metric, value, units=None, lower_is_better=True,
                                        classifiers={'test_name': test_name, 'rep': rep})


### PR DESCRIPTION
Pandas removed .ix as a way to iterate the index, .loc is the replacement
in most cases. Jankbench as a workload fails on a clean install due to
this call.

Replacing this works for me on a native install of Lisa with Ubuntu 20.04

Signed-off-by: Chris Redpath <chris.redpath@arm.com>