### PR TITLE
framework, tests, commands: Update state tracking

### DIFF
--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1,0 +1,225 @@
+#    Copyright 2020 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import tempfile
+from unittest import TestCase
+
+from mock.mock import Mock
+from nose.tools import assert_equal
+from datetime import datetime
+
+from wa.framework.configuration import RunConfiguration
+from wa.framework.configuration.core import JobSpec, Status
+from wa.framework.execution import ExecutionContext, Runner
+from wa.framework.job import Job
+from wa.framework.output import RunOutput, init_run_output
+from wa.framework.output_processor import ProcessorManager
+import wa.framework.signal as signal
+from wa.framework.run import JobState
+
+
+class MockConfigManager(Mock):
+
+    @property
+    def jobs(self):
+        return self._joblist
+
+    @property
+    def loaded_config_sources(self):
+        return []
+
+    @property
+    def run_config(self):
+        return RunConfiguration()
+
+    @property
+    def plugin_cache(self):
+        return MockPluginCache()
+
+    def __init__(self, *args, **kwargs):
+        super(MockConfigManager, self).__init__(*args, **kwargs)
+        self._joblist = None
+        self._run_config = RunConfiguration()
+
+    def to_pod(self):
+        return {}
+
+
+class MockPluginCache(Mock):
+
+    def list_plugins(self, kind=None):
+        return []
+
+
+class MockProcessorManager(Mock):
+
+    def __init__(self, *args, **kwargs):
+        super(MockProcessorManager, self).__init__(*args, **kwargs)
+
+    def get_enabled(self):
+        return []
+
+
+class JobState_force_retry(JobState):
+
+    @property
+    def status(self):
+        return self._status
+
+    @status.setter
+    def status(self, value):
+        if(self.retries != self.times_to_retry) and (value == Status.RUNNING):
+            self._status = Status.FAILED
+            if self.output:
+                self.output.status = Status.FAILED
+        else:
+            self._status = value
+            if self.output:
+                self.output.status = value
+
+    def __init__(self, to_retry, *args, **kwargs):
+        self.retries = 0
+        self._status = Status.NEW
+        self.times_to_retry = to_retry
+        self.output = None
+        super(JobState_force_retry, self).__init__(*args, **kwargs)
+
+
+class Job_force_retry(Job):
+    '''This class imitates a job that retries as many times as specified by
+    ``retries`` in its constructor'''
+
+    def __init__(self, to_retry, *args, **kwargs):
+        super(Job_force_retry, self).__init__(*args, **kwargs)
+        self.state = JobState_force_retry(to_retry, self.id, self.label, self.iteration, Status.NEW)
+
+
+class TestRunState(TestCase):
+
+    def setUp(self):
+        self.path = tempfile.mkstemp()[1]
+        os.remove(self.path)
+        self.initialise_signals()
+
+        config = MockConfigManager()
+        output = init_run_output(self.path, config)
+
+        self.context = ExecutionContext(config, Mock(), output)
+
+        self.job_spec = JobSpec()
+        self.job_spec.augmentations = {}
+        self.job_spec.finalize()
+
+    def tearDown(self):
+        signal.disconnect(self._verify_serialized_state, signal.RUN_INITIALIZED)
+        signal.disconnect(self._verify_serialized_state, signal.JOB_STARTED)
+        signal.disconnect(self._verify_serialized_state, signal.JOB_RESTARTED)
+        signal.disconnect(self._verify_serialized_state, signal.JOB_COMPLETED)
+        signal.disconnect(self._verify_serialized_state, signal.JOB_FAILED)
+        signal.disconnect(self._verify_serialized_state, signal.JOB_ABORTED)
+        signal.disconnect(self._verify_serialized_state, signal.RUN_FINALIZED)
+
+    def test_job_state_transitions_pass(self):
+        '''Tests state equality when the job passes first try'''
+        job = Job(self.job_spec, 1, self.context)
+        job.workload = Mock()
+
+        self.context.cm._joblist = [job]
+        self.context.run_state.add_job(job)
+
+        runner = Runner(self.context, MockProcessorManager())
+        runner.run()
+
+    def test_job_state_transitions_fail(self):
+        '''Tests state equality when job fails completely'''
+        job = Job_force_retry(3, self.job_spec, 1, self.context)
+        job.workload = Mock()
+
+        self.context.cm._joblist = [job]
+        self.context.run_state.add_job(job)
+
+        runner = Runner(self.context, MockProcessorManager())
+        runner.run()
+
+    def test_job_state_transitions_retry(self):
+        '''Tests state equality when job fails initially'''
+        job = Job_force_retry(1, self.job_spec, 1, self.context)
+        job.workload = Mock()
+
+        self.context.cm._joblist = [job]
+        self.context.run_state.add_job(job)
+
+        runner = Runner(self.context, MockProcessorManager())
+        runner.run()
+
+    def initialise_signals(self):
+        signal.connect(self._verify_serialized_state, signal.RUN_INITIALIZED)
+        signal.connect(self._verify_serialized_state, signal.JOB_STARTED)
+        signal.connect(self._verify_serialized_state, signal.JOB_RESTARTED)
+        signal.connect(self._verify_serialized_state, signal.JOB_COMPLETED)
+        signal.connect(self._verify_serialized_state, signal.JOB_FAILED)
+        signal.connect(self._verify_serialized_state, signal.JOB_ABORTED)
+        signal.connect(self._verify_serialized_state, signal.RUN_FINALIZED)
+
+    def _verify_serialized_state(self, _):
+        fs_state = RunOutput(self.path).state
+        ex_state = self.context.run_output.state
+
+        assert_equal(fs_state.status, ex_state.status)
+        fs_js_zip = zip(
+            [value for key, value in fs_state.jobs.items()],
+            [value for key, value in ex_state.jobs.items()]
+        )
+        for fs_jobstate, ex_jobstate in fs_js_zip:
+            assert_equal(fs_jobstate.iteration, ex_jobstate.iteration)
+            assert_equal(fs_jobstate.retries, ex_jobstate.retries)
+            assert_equal(fs_jobstate.status, ex_jobstate.status)
+
+
+class TestJobState(TestCase):
+
+    def setUp(self):
+        path = tempfile.mkstemp()[1]
+        os.remove(path)
+        self.initialise_signals()
+
+        config = MockConfigManager()
+        output = init_run_output(path, config)
+
+        self.context = ExecutionContext(config, Mock(), output)
+
+    def test_job_retry_status(self):
+        job_spec = JobSpec()
+        job_spec.augmentations = {}
+        job_spec.finalize()
+
+        self.job = Job_force_retry(2, job_spec, 1, self.context)
+        self.job.workload = Mock()
+
+        self.context.cm._joblist = [self.job]
+        self.context.run_state.add_job(self.job)
+
+        runner = Runner(self.context, MockProcessorManager())
+        runner.run()
+
+    def initialise_signals(self):
+        signal.connect(self._verify_restarted_job_status, signal.JOB_RESTARTED)
+
+    def tearDown(self):
+        signal.disconnect(self._verify_restarted_job_status, signal.JOB_RESTARTED)
+
+    def _verify_restarted_job_status(self, _):
+        assert_equal(self.job.status, Status.PENDING)

--- a/wa/commands/report.py
+++ b/wa/commands/report.py
@@ -1,0 +1,288 @@
+from collections import Counter
+from datetime import datetime, timedelta
+import logging
+import os
+
+from wa import Command, settings
+from wa.framework.configuration.core import Status
+from wa.framework.output import RunOutput, discover_wa_outputs
+from wa.utils.doc import underline
+from wa.utils.log import COLOR_MAP, RESET_COLOR
+from wa.utils.terminalsize import get_terminal_size
+
+
+class ReportCommand(Command):
+
+    name = 'report'
+    description = '''
+    Monitor an ongoing run and provide information on its progress.
+
+    Specify the output directory of the run you would like the monitor;
+    alternatively report will attempt to discover wa output directories
+    within the current directory. The output includes run information such as
+    the UUID, start time, duration, project name and a short summary of the
+    run's progress (number of completed jobs, the number of jobs in each
+    different status).
+
+    If verbose output is specified, the output includes a list of all events
+    labelled as not specific to any job, followed by a list of the jobs in the
+    order executed, with their retries (if any), current status and, if the job
+    is finished, a list of events that occurred during that job's execution.
+
+    This is an example of a job status line:
+
+        wk1 (exoplayer) [1] - 2, PARTIAL
+
+    It contains two entries delimited by a comma: the job's descriptor followed
+    by its completion status (``PARTIAL``, in this case). The descriptor
+    consists of the following elements:
+
+        - the job ID (``wk1``)
+        - the job label (which defaults to the workload name) in parentheses
+        - job iteration number in square brakets (``1`` in this case)
+        - a hyphen followed by the retry attempt number.
+            (note: this will only be shown if the job has been retried as least
+            once. If the job has not yet run, or if it completed on the first
+            attempt, the hyphen and retry count -- which in that case would be
+            zero -- will not appear).
+    '''
+
+    def initialize(self, context):
+        self.parser.add_argument('-d', '--directory',
+                                 help='''
+                                 Specify the WA output path. report will
+                                 otherwise attempt to discover output
+                                 directories in the current directory.
+                                 ''')
+
+    def execute(self, state, args):
+        if args.directory:
+            output_path = args.directory
+            run_output = RunOutput(output_path)
+        else:
+            possible_outputs = list(discover_wa_outputs(os.getcwd()))
+            num_paths = len(possible_outputs)
+
+            if num_paths > 1:
+                print('More than one possible output directory found,'
+                      ' please choose a path from the following:'
+                      )
+
+                for i in range(num_paths):
+                    print("{}: {}".format(i, possible_outputs[i].basepath))
+
+                while True:
+                    try:
+                        select = int(input())
+                    except ValueError:
+                        print("Please select a valid path number")
+                        continue
+
+                    if select not in range(num_paths):
+                        print("Please select a valid path number")
+                        continue
+                    break
+
+                run_output = possible_outputs[select]
+
+            else:
+                run_output = possible_outputs[0]
+
+        rm = RunMonitor(run_output)
+        print(rm.generate_output(args.verbose))
+
+
+class RunMonitor:
+
+    @property
+    def elapsed_time(self):
+        if self._elapsed is None:
+            if self.ro.info.duration is None:
+                self._elapsed = datetime.utcnow() - self.ro.info.start_time
+            else:
+                self._elapsed = self.ro.info.duration
+        return self._elapsed
+
+    @property
+    def job_outputs(self):
+        if self._job_outputs is None:
+            self._job_outputs = {
+                (j_o.id, j_o.label, j_o.iteration): j_o for j_o in self.ro.jobs
+            }
+        return self._job_outputs
+
+    @property
+    def projected_duration(self):
+        elapsed = self.elapsed_time.total_seconds()
+        proj = timedelta(seconds=elapsed * (len(self.jobs) / len(self.segmented['finished'])))
+        return proj - self.elapsed_time
+
+    def __init__(self, ro):
+        self.ro = ro
+        self._elapsed = None
+        self._p_duration = None
+        self._job_outputs = None
+        self._termwidth = None
+        self._fmt = _simple_formatter()
+        self.get_data()
+
+    def get_data(self):
+        self.jobs = [state for label_id, state in self.ro.state.jobs.items()]
+        if self.jobs:
+            rc = self.ro.run_config
+            self.segmented = segment_jobs_by_state(self.jobs,
+                                                   rc.max_retries,
+                                                   rc.retry_on_status
+                                                   )
+
+    def generate_run_header(self):
+        info = self.ro.info
+
+        header = underline('Run Info')
+        header += "UUID: {}\n".format(info.uuid)
+        if info.run_name:
+            header += "Run name: {}\n".format(info.run_name)
+        if info.project:
+            header += "Project: {}\n".format(info.project)
+        if info.project_stage:
+            header += "Project stage: {}\n".format(info.project_stage)
+
+        if info.start_time:
+            duration = _seconds_as_smh(self.elapsed_time.total_seconds())
+            header += ("Start time: {}\n"
+                       "Duration: {:02}:{:02}:{:02}\n"
+                       ).format(info.start_time,
+                                duration[2], duration[1], duration[0],
+                                )
+            if self.segmented['finished'] and not info.end_time:
+                p_duration = _seconds_as_smh(self.projected_duration.total_seconds())
+                header += "Projected time remaining: {:02}:{:02}:{:02}\n".format(
+                    p_duration[2], p_duration[1], p_duration[0]
+                )
+
+            elif self.ro.info.end_time:
+                header += "End time: {}\n".format(info.end_time)
+
+        return header + '\n'
+
+    def generate_job_summary(self):
+        total = len(self.jobs)
+        num_fin = len(self.segmented['finished'])
+
+        summary = underline('Job Summary')
+        summary += 'Total: {}, Completed: {} ({}%)\n'.format(
+            total, num_fin, (num_fin / total) * 100
+        ) if total > 0 else 'No jobs created\n'
+
+        ctr = Counter()
+        for run_state, jobs in ((k, v) for k, v in self.segmented.items() if v):
+            if run_state == 'finished':
+                ctr.update([job.status.name.lower() for job in jobs])
+            else:
+                ctr[run_state] += len(jobs)
+
+        return summary + ', '.join(
+            [str(count) + ' ' + self._fmt.highlight_keyword(status) for status, count in ctr.items()]
+        ) + '\n\n'
+
+    def generate_job_detail(self):
+        detail = underline('Job Detail')
+        for job in self.jobs:
+            detail += ('{} ({}) [{}]{}, {}\n').format(
+                job.id,
+                job.label,
+                job.iteration,
+                ' - ' + str(job.retries)if job.retries else '',
+                self._fmt.highlight_keyword(str(job.status))
+            )
+
+            job_output = self.job_outputs[(job.id, job.label, job.iteration)]
+            for event in job_output.events:
+                detail += self._fmt.fit_term_width(
+                    '\t{}\n'.format(event.summary)
+                )
+        return detail
+
+    def generate_run_detail(self):
+        detail = underline('Run Events') if self.ro.events else ''
+
+        for event in self.ro.events:
+            detail += '{}\n'.format(event.summary)
+
+        return detail + '\n'
+
+    def generate_output(self, verbose):
+        if not self.jobs:
+            return 'No jobs found in output directory\n'
+
+        output = self.generate_run_header()
+        output += self.generate_job_summary()
+
+        if verbose:
+            output += self.generate_run_detail()
+            output += self.generate_job_detail()
+
+        return output
+
+
+def _seconds_as_smh(seconds):
+    seconds = int(seconds)
+    hours = seconds // 3600
+    minutes = (seconds % 3600) // 60
+    seconds = seconds % 60
+    return seconds, minutes, hours
+
+
+def segment_jobs_by_state(jobstates, max_retries, retry_status):
+    finished_states = [
+        Status.PARTIAL, Status.FAILED,
+        Status.ABORTED, Status.OK, Status.SKIPPED
+    ]
+
+    segmented = {
+        'finished': [], 'other': [], 'running': [],
+        'pending': [], 'uninitialized': []
+    }
+
+    for jobstate in jobstates:
+        if (jobstate.status in retry_status) and jobstate.retries < max_retries:
+            segmented['running'].append(jobstate)
+        elif jobstate.status in finished_states:
+            segmented['finished'].append(jobstate)
+        elif jobstate.status == Status.RUNNING:
+            segmented['running'].append(jobstate)
+        elif jobstate.status == Status.PENDING:
+            segmented['pending'].append(jobstate)
+        elif jobstate.status == Status.NEW:
+            segmented['uninitialized'].append(jobstate)
+        else:
+            segmented['other'].append(jobstate)
+
+    return segmented
+
+
+class _simple_formatter:
+    color_map = {
+        'running': COLOR_MAP[logging.INFO],
+        'partial': COLOR_MAP[logging.WARNING],
+        'failed': COLOR_MAP[logging.CRITICAL],
+        'aborted': COLOR_MAP[logging.ERROR]
+    }
+
+    def __init__(self):
+        self.termwidth = get_terminal_size()[0]
+        self.color = settings.logging['color']
+
+    def fit_term_width(self, text):
+        text = text.expandtabs()
+        if len(text) <= self.termwidth:
+            return text
+        else:
+            return text[0:self.termwidth - 4] + " ...\n"
+
+    def highlight_keyword(self, kw):
+        if not self.color or kw not in _simple_formatter.color_map:
+            return kw
+
+        color = _simple_formatter.color_map[kw.lower()]
+        return '{}{}{}'.format(color, kw, RESET_COLOR)

--- a/wa/framework/run.py
+++ b/wa/framework/run.py
@@ -102,13 +102,7 @@ class RunState(Podable):
         self.timestamp = datetime.utcnow()
 
     def add_job(self, job):
-        job_state = JobState(job.id, job.label, job.iteration, job.status)
-        self.jobs[(job_state.id, job_state.iteration)] = job_state
-
-    def update_job(self, job):
-        state = self.jobs[(job.id, job.iteration)]
-        state.status = job.status
-        state.timestamp = datetime.utcnow()
+        self.jobs[(job.state.id, job.state.iteration)] = job.state
 
     def get_status_counts(self):
         counter = Counter()

--- a/wa/framework/run.py
+++ b/wa/framework/run.py
@@ -163,7 +163,7 @@ class JobState(Podable):
         pod['label'] = self.label
         pod['iteration'] = self.iteration
         pod['status'] = self.status.to_pod()
-        pod['retries'] = 0
+        pod['retries'] = self.retries
         pod['timestamp'] = self.timestamp
         return pod
 

--- a/wa/framework/signal.py
+++ b/wa/framework/signal.py
@@ -15,7 +15,7 @@
 
 
 """
-This module wraps louie signalling mechanism. It relies on modified version of loiue
+This module wraps louie signalling mechanism. It relies on modified version of louie
 that has prioritization added to handler invocation.
 
 """
@@ -23,8 +23,9 @@ import sys
 import logging
 from contextlib import contextmanager
 
+from louie import dispatcher, saferef  # pylint: disable=wrong-import-order
+from louie.dispatcher import _remove_receiver
 import wrapt
-from louie import dispatcher  # pylint: disable=wrong-import-order
 
 from wa.utils.types import prioritylist, enum
 
@@ -242,8 +243,8 @@ def connect(handler, signal, sender=dispatcher.Any, priority=0):
         receivers = signals[signal]
     else:
         receivers = signals[signal] = _prioritylist_wrapper()
-    receivers.add(handler, priority)
     dispatcher.connect(handler, signal, sender)
+    receivers.add(saferef.safe_ref(handler, on_delete=_remove_receiver), priority)
 
 
 def disconnect(handler, signal, sender=dispatcher.Any):
@@ -268,7 +269,7 @@ def send(signal, sender=dispatcher.Anonymous, *args, **kwargs):
     """
     Sends a signal, causing connected handlers to be invoked.
 
-    Paramters:
+    Parameters:
 
         :signal: Signal to be sent. This must be an instance of :class:`wa.core.signal.Signal`
                  or its subclasses.


### PR DESCRIPTION
 - Test benches provided to track the serialisation of execution state to
the state file, and for the state of a retried job
 
  - These were necessary to show that
         a) Retried jobs did not have the correct status
         b) Job status was not reflected promptly in the state file

- Serialisation was coupled with setting job status to prevent this,
and JobState was consolidated inside Job to aid status consistency.

- Added runstatus command for the monitoring of ongoing and
completed WA runs. 

- Fixed signal disconnection and added testcase