### PR TITLE
travis: Limit the maximum version of isort

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ install:
     - pip install nose
     - pip install nose2
     - pip install flake8
+    - pip install isort==4.3.21
     - pip install pylint==1.9.2
     - git clone -v https://github.com/ARM-software/devlib.git /tmp/devlib && cd /tmp/devlib && python setup.py install
     - cd $TRAVIS_BUILD_DIR && python setup.py install


### PR DESCRIPTION
The later versions of isort is not compatible with the version of
pylint we use so ensure we use a compatible version in the travis tests.