### PR TITLE
WIP: Code Optimisations 

### DIFF
--- a/wa/framework/configuration/core.py
+++ b/wa/framework/configuration/core.py
@@ -538,6 +538,10 @@ class MetaConfiguration(Configuration):
     def target_info_cache_file(self):
         return os.path.join(self.cache_directory, 'targets.json')
 
+    @property
+    def apk_info_cache_file(self):
+        return os.path.join(self.cache_directory, 'apk_info.json')
+
     def __init__(self, environ=None):
         super(MetaConfiguration, self).__init__()
         if environ is None:

--- a/wa/framework/getters.py
+++ b/wa/framework/getters.py
@@ -31,7 +31,7 @@ import requests
 from wa import Parameter, settings, __file__ as _base_filepath
 from wa.framework.resource import ResourceGetter, SourcePriority, NO_ONE
 from wa.framework.exception import ResourceError
-from wa.utils.misc import (ensure_directory_exists as _d, lock_file,
+from wa.utils.misc import (ensure_directory_exists as _d, atomic_write_path,
                            ensure_file_directory_exists as _f, sha256, urljoin)
 from wa.utils.types import boolean, caseless_string
 
@@ -254,21 +254,22 @@ class Http(ResourceGetter):
         url = urljoin(self.url, owner_name, asset['path'])
         local_path = _f(os.path.join(settings.dependencies_directory, '__remote',
                                      owner_name, asset['path'].replace('/', os.sep)))
-        with lock_file(local_path, timeout=5 * 60):
-            if os.path.exists(local_path) and not self.always_fetch:
-                local_sha = sha256(local_path)
-                if local_sha == asset['sha256']:
-                    self.logger.debug('Local SHA256 matches; not re-downloading')
-                    return local_path
-            self.logger.debug('Downloading {}'.format(url))
-            response = self.geturl(url, stream=True)
-            if response.status_code != http.client.OK:
-                message = 'Could not download asset "{}"; recieved "{} {}"'
-                self.logger.warning(message.format(url,
-                                                   response.status_code,
-                                                   response.reason))
-                return
-            with open(local_path, 'wb') as wfh:
+
+        if os.path.exists(local_path) and not self.always_fetch:
+            local_sha = sha256(local_path)
+            if local_sha == asset['sha256']:
+                self.logger.debug('Local SHA256 matches; not re-downloading')
+                return local_path
+        self.logger.debug('Downloading {}'.format(url))
+        response = self.geturl(url, stream=True)
+        if response.status_code != http.client.OK:
+            message = 'Could not download asset "{}"; received "{} {}"'
+            self.logger.warning(message.format(url,
+                                               response.status_code,
+                                               response.reason))
+            return
+        with atomic_write_path(local_path) as at_path:
+            with open(at_path, 'wb') as wfh:
                 for chunk in response.iter_content(chunk_size=self.chunk_size):
                     wfh.write(chunk)
         return local_path

--- a/wa/framework/getters.py
+++ b/wa/framework/getters.py
@@ -239,7 +239,7 @@ class Http(ResourceGetter):
         index_url = urljoin(self.url, 'index.json')
         response = self.geturl(index_url)
         if response.status_code != http.client.OK:
-            message = 'Could not fetch "{}"; recieved "{} {}"'
+            message = 'Could not fetch "{}"; received "{} {}"'
             self.logger.error(message.format(index_url,
                                              response.status_code,
                                              response.reason))

--- a/wa/framework/resource.py
+++ b/wa/framework/resource.py
@@ -16,16 +16,14 @@ import logging
 import os
 import re
 
-from devlib.utils.android import ApkInfo
-
 from wa.framework import pluginloader
 from wa.framework.plugin import Plugin
 from wa.framework.exception import ResourceError
 from wa.framework.configuration import settings
 from wa.utils import log
+from wa.utils.android import get_cacheable_apk_info
 from wa.utils.misc import get_object_name
 from wa.utils.types import enum, list_or_string, prioritylist, version_tuple
-from wa.utils.misc import lock_file
 
 
 SourcePriority = enum(['package', 'remote', 'lan', 'local',
@@ -281,8 +279,7 @@ class ResourceResolver(object):
 
 def apk_version_matches(path, version):
     version = list_or_string(version)
-    with lock_file(path):
-        info = ApkInfo(path)
+    info = get_cacheable_apk_info(path)
     for v in version:
         if info.version_name == v or info.version_code == v:
             return True
@@ -292,8 +289,7 @@ def apk_version_matches(path, version):
 
 
 def apk_version_matches_range(path, min_version=None, max_version=None):
-    with lock_file(path):
-        info = ApkInfo(path)
+    info = get_cacheable_apk_info(path)
     return range_version_matching(info.version_name, min_version, max_version)
 
 
@@ -336,21 +332,18 @@ def file_name_matches(path, pattern):
 
 
 def uiauto_test_matches(path, uiauto):
-    with lock_file(path):
-        info = ApkInfo(path)
+    info = get_cacheable_apk_info(path)
     return uiauto == ('com.arm.wa.uiauto' in info.package)
 
 
 def package_name_matches(path, package):
-    with lock_file(path):
-        info = ApkInfo(path)
+    info = get_cacheable_apk_info(path)
     return info.package == package
 
 
 def apk_abi_matches(path, supported_abi, exact_abi=False):
     supported_abi = list_or_string(supported_abi)
-    with lock_file(path):
-        info = ApkInfo(path)
+    info = get_cacheable_apk_info(path)
     # If no native code present, suitable for all devices.
     if not info.native_code:
         return True

--- a/wa/framework/target/info.py
+++ b/wa/framework/target/info.py
@@ -23,7 +23,7 @@ from devlib.utils.android import AndroidProperties
 from wa.framework.configuration.core import settings
 from wa.framework.exception import ConfigError
 from wa.utils.serializer import read_pod, write_pod, Podable
-from wa.utils.misc import lock_file
+from wa.utils.misc import atomic_write_path
 
 
 def cpuinfo_from_pod(pod):
@@ -281,15 +281,14 @@ def read_target_info_cache():
         os.makedirs(settings.cache_directory)
     if not os.path.isfile(settings.target_info_cache_file):
         return {}
-    with lock_file(settings.target_info_cache_file):
-        return read_pod(settings.target_info_cache_file)
+    return read_pod(settings.target_info_cache_file)
 
 
 def write_target_info_cache(cache):
     if not os.path.exists(settings.cache_directory):
         os.makedirs(settings.cache_directory)
-    with lock_file(settings.target_info_cache_file):
-        write_pod(cache, settings.target_info_cache_file)
+    with atomic_write_path(settings.target_info_cache_file) as at_path:
+        write_pod(cache, at_path)
 
 
 def get_target_info_from_cache(system_id, cache=None):

--- a/wa/framework/target/info.py
+++ b/wa/framework/target/info.py
@@ -292,8 +292,9 @@ def write_target_info_cache(cache):
         write_pod(cache, settings.target_info_cache_file)
 
 
-def get_target_info_from_cache(system_id):
-    cache = read_target_info_cache()
+def get_target_info_from_cache(system_id, cache=None):
+    if cache is None:
+        cache = read_target_info_cache()
     pod = cache.get(system_id, None)
 
     if not pod:
@@ -307,8 +308,9 @@ def get_target_info_from_cache(system_id):
     return TargetInfo.from_pod(pod)
 
 
-def cache_target_info(target_info, overwrite=False):
-    cache = read_target_info_cache()
+def cache_target_info(target_info, overwrite=False, cache=None):
+    if cache is None:
+        cache = read_target_info_cache()
     if target_info.system_id in cache and not overwrite:
         raise ValueError('TargetInfo for {} is already in cache.'.format(target_info.system_id))
     cache[target_info.system_id] = target_info.to_pod()

--- a/wa/framework/target/manager.py
+++ b/wa/framework/target/manager.py
@@ -24,7 +24,8 @@ from wa.framework.plugin import Parameter
 from wa.framework.target.descriptor import (get_target_description,
                                             instantiate_target,
                                             instantiate_assistant)
-from wa.framework.target.info import get_target_info, get_target_info_from_cache, cache_target_info
+from wa.framework.target.info import (get_target_info, get_target_info_from_cache,
+                                      cache_target_info, read_target_info_cache)
 from wa.framework.target.runtime_parameter_manager import RuntimeParameterManager
 from wa.utils.types import module_name_set
 
@@ -92,18 +93,19 @@ class TargetManager(object):
 
     @memoized
     def get_target_info(self):
-        info = get_target_info_from_cache(self.target.system_id)
+        cache = read_target_info_cache()
+        info = get_target_info_from_cache(self.target.system_id, cache=cache)
 
         if info is None:
             info = get_target_info(self.target)
-            cache_target_info(info)
+            cache_target_info(info, cache=cache)
         else:
             # If module configuration has changed form when the target info
             # was previously cached, it is possible additional info will be
             # available, so should re-generate the cache.
             if module_name_set(info.modules) != module_name_set(self.target.modules):
                 info = get_target_info(self.target)
-                cache_target_info(info, overwrite=True)
+                cache_target_info(info, overwrite=True, cache=cache)
 
         return info
 

--- a/wa/framework/workload.py
+++ b/wa/framework/workload.py
@@ -22,8 +22,8 @@ try:
 except ImportError:
     from pipes import quote
 
-from devlib.utils.android import ApkInfo
 
+from wa.utils.android import get_cacheable_apk_info
 from wa.framework.plugin import TargetedPlugin, Parameter
 from wa.framework.resource import (ApkFile, ReventFile,
                                    File, loose_version_matching,
@@ -523,7 +523,7 @@ class UiAutomatorGUI(object):
     def init_resources(self, resolver):
         self.uiauto_file = resolver.get(ApkFile(self.owner, uiauto=True))
         if not self.uiauto_package:
-            uiauto_info = ApkInfo(self.uiauto_file)
+            uiauto_info = get_cacheable_apk_info(self.uiauto_file)
             self.uiauto_package = uiauto_info.package
 
     def init_commands(self):
@@ -743,8 +743,7 @@ class PackageHandler(object):
                     self.resolve_package_from_host(context)
 
             if self.apk_file:
-                with lock_file(self.apk_file):
-                    self.apk_info = ApkInfo(self.apk_file)
+                self.apk_info = get_cacheable_apk_info(self.apk_file)
             else:
                 if self.error_msg:
                     raise WorkloadError(self.error_msg)

--- a/wa/framework/workload.py
+++ b/wa/framework/workload.py
@@ -32,7 +32,7 @@ from wa.framework.exception import WorkloadError, ConfigError
 from wa.utils.types import ParameterDict, list_or_string, version_tuple
 from wa.utils.revent import ReventRecorder
 from wa.utils.exec_control import once_per_instance
-from wa.utils.misc import lock_file
+from wa.utils.misc import atomic_write_path
 
 
 class Workload(TargetedPlugin):
@@ -732,32 +732,31 @@ class PackageHandler(object):
             raise WorkloadError(msg)
 
         self.error_msg = None
-        with lock_file(os.path.join(self.owner.dependencies_directory, self.owner.name)):
-            if self.prefer_host_package:
-                self.resolve_package_from_host(context)
-                if not self.apk_file:
-                    self.resolve_package_from_target()
-            else:
+        if self.prefer_host_package:
+            self.resolve_package_from_host(context)
+            if not self.apk_file:
                 self.resolve_package_from_target()
-                if not self.apk_file:
-                    self.resolve_package_from_host(context)
+        else:
+            self.resolve_package_from_target()
+            if not self.apk_file:
+                self.resolve_package_from_host(context)
 
-            if self.apk_file:
-                self.apk_info = get_cacheable_apk_info(self.apk_file)
+        if self.apk_file:
+            self.apk_info = get_cacheable_apk_info(self.apk_file)
+        else:
+            if self.error_msg:
+                raise WorkloadError(self.error_msg)
             else:
-                if self.error_msg:
-                    raise WorkloadError(self.error_msg)
+                if self.package_name:
+                    message = 'Package "{package}" not found for workload {name} '\
+                              'on host or target.'
+                elif self.version:
+                    message = 'No matching package found for workload {name} '\
+                              '(version {version}) on host or target.'
                 else:
-                    if self.package_name:
-                        message = 'Package "{package}" not found for workload {name} '\
-                                  'on host or target.'
-                    elif self.version:
-                        message = 'No matching package found for workload {name} '\
-                                  '(version {version}) on host or target.'
-                    else:
-                        message = 'No matching package found for workload {name} on host or target'
-                    raise WorkloadError(message.format(name=self.owner.name, version=self.version,
-                                                       package=self.package_name))
+                    message = 'No matching package found for workload {name} on host or target'
+                raise WorkloadError(message.format(name=self.owner.name, version=self.version,
+                                                   package=self.package_name))
 
     def resolve_package_from_host(self, context):
         self.logger.debug('Resolving package on host system')
@@ -900,8 +899,8 @@ class PackageHandler(object):
         package_info = self.target.get_package_info(package)
         apk_name = self._get_package_name(package_info.apk_path)
         host_path = os.path.join(self.owner.dependencies_directory, apk_name)
-        with lock_file(host_path, timeout=self.install_timeout):
-            self.target.pull(package_info.apk_path, host_path,
+        with atomic_write_path(host_path) as at_path:
+            self.target.pull(package_info.apk_path, at_path,
                              timeout=self.install_timeout)
         return host_path
 

--- a/wa/instruments/misc.py
+++ b/wa/instruments/misc.py
@@ -32,16 +32,16 @@ import tarfile
 from subprocess import CalledProcessError
 
 from devlib.exception import TargetError
-from devlib.utils.android import ApkInfo
 
 from wa import Instrument, Parameter, very_fast
 from wa.framework.exception import ConfigError
 from wa.framework.instrument import slow
 from wa.utils.diff import diff_sysfs_dirs, diff_interrupt_files
-from wa.utils.misc import as_relative, lock_file
+from wa.utils.misc import as_relative
 from wa.utils.misc import ensure_file_directory_exists as _f
 from wa.utils.misc import ensure_directory_exists as _d
 from wa.utils.types import list_of_strings
+from wa.utils.android import get_cacheable_apk_info
 
 
 logger = logging.getLogger(__name__)
@@ -244,8 +244,7 @@ class ApkVersion(Instrument):
 
     def setup(self, context):
         if hasattr(context.workload, 'apk_file'):
-            with lock_file(context.workload.apk_file):
-                self.apk_info = ApkInfo(context.workload.apk_file)
+            self.apk_info = get_cacheable_apk_info(context.workload.apk_file)
         else:
             self.apk_info = None
 

--- a/wa/utils/android.py
+++ b/wa/utils/android.py
@@ -19,8 +19,7 @@ from datetime import datetime
 
 from devlib.utils.android import ApkInfo as _ApkInfo
 
-from wa import settings
-from wa.framework.exception import ConfigError
+from wa.framework.configuration import settings
 from wa.utils.serializer import read_pod, write_pod, Podable
 from wa.utils.types import enum
 from wa.utils.misc import lock_file
@@ -30,7 +29,10 @@ LogcatLogLevel = enum(['verbose', 'debug', 'info', 'warn', 'error', 'assert'], s
 
 log_level_map = ''.join(n[0].upper() for n in LogcatLogLevel.names)
 
-logger = logging.getLogger('logcat')
+logcat_logger = logging.getLogger('logcat')
+apk_info_cache_logger = logging.getLogger('apk_info_cache')
+
+apk_info_cache = None
 
 
 class LogcatEvent(object):
@@ -81,14 +83,15 @@ class LogcatParser(object):
             tag = (parts.pop(0) if parts else '').strip()
         except Exception as e:  # pylint: disable=broad-except
             message = 'Invalid metadata for line:\n\t{}\n\tgot: "{}"'
-            logger.warning(message.format(line, e))
+            logcat_logger.warning(message.format(line, e))
             return None
 
         return LogcatEvent(timestamp, pid, tid, level, tag, message)
 
 
+# pylint: disable=protected-access,attribute-defined-outside-init
 class ApkInfo(_ApkInfo, Podable):
-    # Implement ApkInfo as a Podable class.
+    '''Implement ApkInfo as a Podable class.'''
 
     _pod_serialization_version = 1
 
@@ -132,3 +135,66 @@ class ApkInfo(_ApkInfo, Podable):
         pod['_pod_version'] = pod.get('_pod_version', 1)
         return pod
 
+
+class ApkInfoCache:
+
+    @staticmethod
+    def _check_env():
+        if not os.path.exists(settings.cache_directory):
+            os.makedirs(settings.cache_directory)
+
+    def __init__(self, path=settings.apk_info_cache_file):
+        self._check_env()
+        self.path = path
+        self.last_modified = None
+        self.cache = {}
+        self._update_cache()
+
+    def store(self, apk_info, apk_id, overwrite=True):
+        self._update_cache()
+        if apk_id in self.cache and not overwrite:
+            raise ValueError('ApkInfo for {} is already in cache.'.format(apk_info.path))
+        self.cache[apk_id] = apk_info.to_pod()
+        with lock_file(self.path):
+            write_pod(self.cache, self.path)
+            self.last_modified = os.stat(self.path)
+
+    def get_info(self, key):
+        self._update_cache()
+        pod = self.cache.get(key)
+
+        info = ApkInfo.from_pod(pod) if pod else None
+        return info
+
+    def _update_cache(self):
+        if not os.path.exists(self.path):
+            return
+        if self.last_modified != os.stat(self.path):
+            apk_info_cache_logger.debug('Updating cache {}'.format(self.path))
+            with lock_file(self.path):
+                self.cache = read_pod(self.path)
+                self.last_modified = os.stat(self.path)
+
+
+def get_cacheable_apk_info(path):
+    # pylint: disable=global-statement
+    global apk_info_cache
+    if not path:
+        return
+    stat = os.stat(path)
+    modified = stat.st_mtime
+    apk_id = '{}-{}'.format(path, modified)
+    info = apk_info_cache.get_info(apk_id)
+
+    if info:
+        msg = 'Using ApkInfo ({}) from cache'.format(info.package)
+    else:
+        with lock_file(path):
+            info = ApkInfo(path)
+        apk_info_cache.store(info, apk_id, overwrite=True)
+        msg = 'Storing ApkInfo ({}) in cache'.format(info.package)
+    apk_info_cache_logger.debug(msg)
+    return info
+
+
+apk_info_cache = ApkInfoCache()


### PR DESCRIPTION
- To prevent the requirement of parsing an APK file multiple times cache the information using its path and last modified time and keep a copy in memory. This should improve execution times when using large APK files and reduce contention when running with multiple instances of WA.
- To prevent long timeouts occurring during to file locking on both reads and writes implement and replace locking with atomic writes. While this may results in cache entries being overwritten, the amount of time used in duplicated retrievals will likely be saved with the prevention of stalls due to waiting to acquire the file lock.
- Generate the md5 hash of assets in chunks to prevent loading large files into memory at once.

Supersedes #1100 