### PR TITLE
postgres_schemas: Add rules for cascading deletes

### DIFF
--- a/wa/commands/postgres_schemas/postgres_schema_update_v1.6.sql
+++ b/wa/commands/postgres_schemas/postgres_schema_update_v1.6.sql
@@ -1,0 +1,109 @@
+ALTER TABLE jobs
+    DROP CONSTRAINT jobs_run_oid_fkey,
+    ADD CONSTRAINT jobs_run_oid_fkey
+        FOREIGN KEY (run_oid)
+        REFERENCES runs(oid)
+        ON DELETE CASCADE
+;
+
+ALTER TABLE targets
+    DROP CONSTRAINT targets_run_oid_fkey,
+    ADD CONSTRAINT targets_run_oid_fkey
+        FOREIGN KEY (run_oid)
+        REFERENCES runs(oid)
+        ON DELETE CASCADE
+;
+
+ALTER TABLE events
+    DROP CONSTRAINT events_run_oid_fkey,
+    ADD CONSTRAINT events_run_oid_fkey
+        FOREIGN KEY (run_oid)
+        REFERENCES runs(oid)
+        ON DELETE CASCADE
+;
+
+ALTER TABLE resource_getters
+    DROP CONSTRAINT resource_getters_run_oid_fkey,
+    ADD CONSTRAINT resource_getters_run_oid_fkey
+        FOREIGN KEY (run_oid)
+        REFERENCES runs(oid)
+        ON DELETE CASCADE
+;
+
+ALTER TABLE augmentations
+    DROP CONSTRAINT augmentations_run_oid_fkey,
+    ADD CONSTRAINT augmentations_run_oid_fkey
+        FOREIGN KEY (run_oid)
+        REFERENCES runs(oid)
+        ON DELETE CASCADE
+;
+
+ALTER TABLE jobs_augs
+    DROP CONSTRAINT jobs_augs_job_oid_fkey,
+    DROP CONSTRAINT jobs_augs_augmentation_oid_fkey,
+    ADD CONSTRAINT jobs_augs_job_oid_fkey
+        FOREIGN KEY (job_oid)
+        REFERENCES Jobs(oid)
+        ON DELETE CASCADE,
+    ADD CONSTRAINT jobs_augs_augmentation_oid_fkey
+        FOREIGN KEY (augmentation_oid)
+        REFERENCES Augmentations(oid)
+        ON DELETE CASCADE
+;
+
+ALTER TABLE metrics
+    DROP CONSTRAINT metrics_run_oid_fkey,
+    ADD CONSTRAINT metrics_run_oid_fkey
+        FOREIGN KEY (run_oid)
+        REFERENCES runs(oid)
+        ON DELETE CASCADE
+;
+
+ALTER TABLE artifacts
+    DROP CONSTRAINT artifacts_run_oid_fkey,
+    ADD CONSTRAINT artifacts_run_oid_fkey
+        FOREIGN KEY (run_oid)
+        REFERENCES runs(oid)
+        ON DELETE CASCADE
+;
+
+CREATE RULE del_lo AS
+    ON DELETE TO Artifacts
+    DO DELETE FROM LargeObjects
+        WHERE LargeObjects.oid = old.large_object_uuid
+;
+
+ALTER TABLE classifiers
+    DROP CONSTRAINT classifiers_artifact_oid_fkey,
+    DROP CONSTRAINT classifiers_metric_oid_fkey,
+    DROP CONSTRAINT classifiers_job_oid_fkey,
+    DROP CONSTRAINT classifiers_run_oid_fkey,
+
+    ADD CONSTRAINT classifiers_artifact_oid_fkey
+        FOREIGN KEY (artifact_oid)
+        REFERENCES artifacts(oid)
+        ON DELETE CASCADE,
+
+    ADD CONSTRAINT classifiers_metric_oid_fkey
+        FOREIGN KEY (metric_oid)
+        REFERENCES metrics(oid)
+        ON DELETE CASCADE,
+
+    ADD CONSTRAINT classifiers_job_oid_fkey
+        FOREIGN KEY (job_oid)
+        REFERENCES jobs(oid)
+        ON DELETE CASCADE,
+
+    ADD CONSTRAINT classifiers_run_oid_fkey
+        FOREIGN KEY (run_oid)
+        REFERENCES runs(oid)
+        ON DELETE CASCADE
+;
+
+ALTER TABLE parameters
+    DROP CONSTRAINT parameters_run_oid_fkey,
+    ADD CONSTRAINT parameters_run_oid_fkey
+        FOREIGN KEY (run_oid)
+        REFERENCES runs(oid)
+        ON DELETE CASCADE
+;

--- a/wa/commands/schema_changelog.rst
+++ b/wa/commands/schema_changelog.rst
@@ -22,3 +22,7 @@
   during the run.
 ## 1.5
 - Change the type of the "hostid" in TargetInfo from Int to Bigint.
+## 1.6
+- Add cascading deletes to most tables to allow easy deletion of a run
+  and its associated data
+- Add rule to delete associated large object on deletion of artifact


### PR DESCRIPTION
Add cascading deletes to foreign keys as well as a rule to delete large
objects when artifacts are deleted.

Deleting a run entry should delete all dependent data of that run.

Issue: https://github.com/ARM-software/workload-automation/issues/1034