### PR TITLE
target/runtime_config: Add support for stay-on

### DIFF
--- a/wa/framework/target/manager.py
+++ b/wa/framework/target/manager.py
@@ -57,6 +57,7 @@ class TargetManager(object):
 
     def initialize(self):
         self._init_target()
+        self.assistant.initialize()
 
         # If target supports hotplugging, online all cpus before perform discovery
         # and restore original configuration after completed.
@@ -77,6 +78,7 @@ class TargetManager(object):
     def finalize(self):
         if not self.target:
             return
+        self.assistant.finalize()
         if self.disconnect or isinstance(self.target.platform, Gem5SimulationPlatform):
             self.logger.info('Disconnecting from the device')
             with signal.wrap('TARGET_DISCONNECT'):


### PR DESCRIPTION
Adds runtime config support for the android setting
``stay_on_while_plugged_in``.

Uses feature introduced [here](https://github.com/ARM-software/devlib/pull/505)
[Github Issue](https://github.com/ARM-software/workload-automation/issues/1106)

The pull request title is misleading, as since the initial
request the stay-on parameter is **no longer** a runtime
configuration, and is now a device configuration. 