### PR TITLE
target/descriptor: Add connection config for polls

### DIFF
--- a/wa/framework/target/descriptor.py
+++ b/wa/framework/target/descriptor.py
@@ -301,6 +301,37 @@ CONNECTION_PARAMS = {
             description="""
             ADB server to connect to.
             """),
+        Parameter(
+            'poll_transfers', kind=bool,
+            default=True,
+            description="""
+            File transfers will be polled for activity. Inactive
+            file transfers are cancelled.
+            """),
+        Parameter(
+            'start_transfer_poll_delay', kind=int,
+            default=30,
+            description="""
+            How long to wait (s) for a transfer to complete
+            before polling transfer activity. Requires ``poll_transfers``
+            to be set.
+            """),
+        Parameter(
+            'total_transfer_timeout', kind=int,
+            default=3600,
+            description="""
+            The total time to elapse before a transfer is cancelled, regardless
+            of its activity. Requires ``poll_transfers`` to be set.
+            """),
+        Parameter(
+            'transfer_poll_period', kind=int,
+            default=30,
+            description="""
+            The period at which transfer activity is sampled. Requires
+            ``poll_transfers`` to be set. Too small values may cause
+            the destination size to appear the same over one or more sample
+            periods, causing improper transfer cancellation.
+            """),
     ],
     SshConnection: [
         Parameter(
@@ -351,7 +382,38 @@ CONNECTION_PARAMS = {
             Allow using SCP as method of file transfer instead
             of the default SFTP.
             """),
-        # Depreciated Parameters
+        Parameter(
+            'poll_transfers', kind=bool,
+            default=True,
+            description="""
+            File transfers will be polled for activity. Inactive
+            file transfers are cancelled.
+            """),
+        Parameter(
+            'start_transfer_poll_delay', kind=int,
+            default=30,
+            description="""
+            How long to wait (s) for a transfer to complete
+            before polling transfer activity. Requires ``poll_transfers``
+            to be set.
+            """),
+        Parameter(
+            'total_transfer_timeout', kind=int,
+            default=3600,
+            description="""
+            The total time to elapse before a transfer is cancelled, regardless
+            of its activity. Requires ``poll_transfers`` to be set.
+            """),
+        Parameter(
+            'transfer_poll_period', kind=int,
+            default=30,
+            description="""
+            The period at which transfer activity is sampled. Requires
+            ``poll_transfers`` to be set. Too small values may cause
+            the destination size to appear the same over one or more sample
+            periods, causing improper transfer cancellation.
+            """),
+        # Deprecated Parameters
         Parameter(
             'telnet', kind=str,
             description="""


### PR DESCRIPTION
Adds connection parameters needed for WA to support file transfer polling.

``poll_transfers`` of type ``bool``, default ``True`` sets whether
transfers should be polled

``transfer_wait_no_poll`` controls the initial time in seconds that the
poller should wait for the transfer to complete before polling its
progress.

Works with changes implemented in [this pull request](https://github.com/ARM-software/devlib/pull/504)