### PR TITLE
pep8: Ignore line break before binary operator

### DIFF
--- a/dev_scripts/pep8
+++ b/dev_scripts/pep8
@@ -6,7 +6,7 @@ DEFAULT_DIRS=(
 
 EXCLUDE=wa/tests,wa/framework/target/descriptor.py
 EXCLUDE_COMMA=
-IGNORE=E501,E265,E266,W391,E401,E402,E731,W504,W605,F401
+IGNORE=E501,E265,E266,W391,E401,E402,E731,W503,W504,W605,F401
 
 if ! hash flake8 2>/dev/null; then
 	echo "flake8 not found in PATH"


### PR DESCRIPTION
PEP8 has switched its guidance [1] for where a line break should occur
in relation to a binary operator, so don't raise this warning for
new code.

[1] https://www.python.org/dev/peps/pep-0008/#should-a-line-break-before-or-after-a-binary-operator