### PR TITLE
fw/runtime_config: Fix case where no available gov for cpu

### DIFF
--- a/wa/framework/target/runtime_config.py
+++ b/wa/framework/target/runtime_config.py
@@ -694,7 +694,7 @@ class CpufreqRuntimeConfig(RuntimeConfig):
             else:
                 common_freqs = common_freqs.intersection(self.supported_cpu_freqs.get(cpu) or set())
                 all_freqs = all_freqs.union(self.supported_cpu_freqs.get(cpu) or set())
-                common_gov = common_gov.intersection(self.supported_cpu_governors.get(cpu))
+                common_gov = common_gov.intersection(self.supported_cpu_governors.get(cpu) or set())
 
         return all_freqs, common_freqs, common_gov
 


### PR DESCRIPTION
Ensure there is a default iterable value in the case there is no
governor entry for a particular cpu.