### PR TITLE
config/core: merge params from different files

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,6 +16,7 @@
 import unittest
 from nose.tools import assert_equal
 
+from wa.framework.configuration.execution import ConfigManager
 from wa.utils.misc import merge_config_values
 
 
@@ -38,3 +39,21 @@ class TestConfigUtils(unittest.TestCase):
             if v2 is not None:
                 assert_equal(type(result), type(v2))
 
+
+
+class TestConfigParser(unittest.TestCase):
+
+    def test_param_merge(self):
+        config = ConfigManager()
+
+        config.load_config({'workload_params': {'one': 1, 'three': {'ex': 'x'}}, 'runtime_params': {'aye': 'a'}}, 'file_one')
+        config.load_config({'workload_params': {'two': 2, 'three': {'why': 'y'}}, 'runtime_params': {'bee': 'b'}}, 'file_two')
+
+        assert_equal(
+            config.jobs_config.job_spec_template['workload_parameters'],
+            {'one': 1, 'two': 2, 'three': {'why': 'y'}},
+        )
+        assert_equal(
+            config.jobs_config.job_spec_template['runtime_parameters'],
+            {'aye': 'a', 'bee': 'b'},
+        )

--- a/wa/framework/configuration/core.py
+++ b/wa/framework/configuration/core.py
@@ -823,12 +823,12 @@ class JobSpec(Configuration):
                            description='''
                            The name of the workload to run.
                            '''),
-        ConfigurationPoint('workload_parameters', kind=obj_dict,
+        ConfigurationPoint('workload_parameters', kind=obj_dict, merge=True,
                            aliases=["params", "workload_params", "parameters"],
                            description='''
                            Parameter to be passed to the workload
                            '''),
-        ConfigurationPoint('runtime_parameters', kind=obj_dict,
+        ConfigurationPoint('runtime_parameters', kind=obj_dict, merge=True,
                            aliases=["runtime_params"],
                            description='''
                            Runtime parameters to be set prior to running


### PR DESCRIPTION
Ensure that runtime and workload parameters specified across multiple
config files and the config section of the agenda are merged rather than
overwritten.