### PR TITLE
fw/descriptor: Update sudo_cmd default

### DIFF
--- a/wa/framework/target/descriptor.py
+++ b/wa/framework/target/descriptor.py
@@ -20,6 +20,7 @@ from devlib import (LinuxTarget, AndroidTarget, LocalLinuxTarget,
                     AdbConnection, SshConnection, LocalConnection,
                     TelnetConnection, Gem5Connection)
 from devlib.target import DEFAULT_SHELL_PROMPT
+from devlib.utils.ssh import DEFAULT_SSH_SUDO_COMMAND
 
 from wa.framework import pluginloader
 from wa.framework.configuration.core import get_config_point_map
@@ -369,7 +370,7 @@ CONNECTION_PARAMS = {
             their host key does not match the systems known host keys. """),
         Parameter(
             'sudo_cmd', kind=str,
-            default="sudo -- sh -c {}",
+            default=DEFAULT_SSH_SUDO_COMMAND,
             description="""
             Sudo command to use. Must have ``{}`` specified
             somewhere in the string it indicate where the command

--- a/wa/framework/version.py
+++ b/wa/framework/version.py
@@ -23,7 +23,7 @@ VersionTuple = namedtuple('Version', ['major', 'minor', 'revision', 'dev'])
 
 version = VersionTuple(3, 2, 1, 'dev4')
 
-required_devlib_version = VersionTuple(1, 2, 1, 'dev4')
+required_devlib_version = VersionTuple(1, 2, 1, 'dev5')
 
 
 def format_version(v):


### PR DESCRIPTION
The WA default `sudo_cmd` is out of date compared to devlib.
Update the command template to include the latest version.
This enables sudo to read a password from stdin and fixes the password
prompt being included in a command output [1].

[1] https://github.com/ARM-software/devlib/pull/509 

