### PR TITLE
Remove explicit file transfer timeouts

### DIFF
--- a/wa/workloads/exoplayer/__init__.py
+++ b/wa/workloads/exoplayer/__init__.py
@@ -173,7 +173,7 @@ class ExoPlayer(ApkWorkload):
                                                        os.path.basename(self.host_video_file))
         if self.force_dependency_push or not self.target.file_exists(self.device_video_file):
             self.logger.info('Copying {} to device.'.format(self.host_video_file))
-            self.target.push(self.host_video_file, self.device_video_file, timeout=120)
+            self.target.push(self.host_video_file, self.device_video_file)
 
         self._original_orientation = self.target.get_rotation()
         self.target.set_rotation(1 if self.landscape else 0)

--- a/wa/workloads/rt_app/__init__.py
+++ b/wa/workloads/rt_app/__init__.py
@@ -162,7 +162,7 @@ class RtApp(Workload):
         self.host_json_config = self._load_json_config(context)
         self.config_file_on_target = self.target.path.join(self.target_working_directory,
                                                            os.path.basename(self.host_json_config))
-        self.target.push(self.host_json_config, self.config_file_on_target, timeout=60)
+        self.target.push(self.host_json_config, self.config_file_on_target)
         self.command = '{} {}'.format(self.target_binary, self.config_file_on_target)
 
         time_buffer = 30
@@ -284,7 +284,7 @@ class RtApp(Workload):
         self.target.execute(tar_command, timeout=300)
         target_path = self.target.path.join(self.target_working_directory, TARBALL_FILENAME)
         host_path = os.path.join(context.output_directory, TARBALL_FILENAME)
-        self.target.pull(target_path, host_path, timeout=120)
+        self.target.pull(target_path, host_path)
         with tarfile.open(host_path, 'r:gz') as tf:
             tf.extractall(context.output_directory)
         os.remove(host_path)


### PR DESCRIPTION
Remove explicit file transfer timeouts and rely on the polling mechanism if required.