### PR TITLE
fw/version: Prevent installation failure on systems without git

### DIFF
--- a/wa/framework/version.py
+++ b/wa/framework/version.py
@@ -48,8 +48,11 @@ def get_wa_version_with_commit():
 
 
 def get_commit():
-    p = Popen(['git', 'rev-parse', 'HEAD'],
-              cwd=os.path.dirname(__file__), stdout=PIPE, stderr=PIPE)
+    try:
+        p = Popen(['git', 'rev-parse', 'HEAD'],
+                  cwd=os.path.dirname(__file__), stdout=PIPE, stderr=PIPE)
+    except FileNotFoundError:
+        return None
     std, _ = p.communicate()
     p.wait()
     if p.returncode:


### PR DESCRIPTION
On systems that do not have git installed WA will currently fail
to install with a FileNotFound Exception. If git is not present then
we will not have a commit hash so just ignore this error.