### PR TITLE
fw/rt_config: Avoid querying online cpus if hotplug disabled

### DIFF
--- a/wa/framework/target/runtime_config.py
+++ b/wa/framework/target/runtime_config.py
@@ -178,7 +178,7 @@ class HotplugRuntimeConfig(RuntimeConfig):
             raise TargetError('Target does not appear to support hotplug')
 
     def validate_parameters(self):
-        if len(self.num_cores) == self.target.number_of_cpus:
+        if self.num_cores and len(self.num_cores) == self.target.number_of_cpus:
             if all(v is False for v in list(self.num_cores.values())):
                 raise ValueError('Cannot set number of all cores to 0')
 


### PR DESCRIPTION
If the device does not have the hoptplug module installed, avoid
unnecessary querying of the device to check the number of cpus which
can cause issues with some devices.