### PR TITLE
fw/job: Fix workload cache check

### DIFF
--- a/wa/framework/job.py
+++ b/wa/framework/job.py
@@ -75,7 +75,7 @@ class Job(object):
 
     def load(self, target, loader=pluginloader):
         self.logger.info('Loading job {}'.format(self))
-        if self.iteration == 1:
+        if self.id not in self._workload_cache:
             self.workload = loader.get_workload(self.spec.workload_name,
                                                 target,
                                                 **self.spec.workload_parameters)


### PR DESCRIPTION
Don't assume the first job iteration is already in the workload cache.
This may not always be the case, for example with the random execution
order a later iteration can be processed first.
Instead check to see if the job id is present or not.