### PR TITLE
Use newly exposed target properties for TargetInfo

### DIFF
--- a/wa/framework/target/info.py
+++ b/wa/framework/target/info.py
@@ -230,15 +230,14 @@ def get_target_info(target):
     info.is_rooted = target.is_rooted
     info.kernel_version = target.kernel_version
     info.kernel_config = target.config
+    info.hostname = target.hostname
+    info.hostid = target.hostid
+
     try:
         info.sched_features = target.read_value('/sys/kernel/debug/sched_features').split()
     except TargetError:
         # best effort -- debugfs might not be mounted
         pass
-
-    hostid_string = target.execute('{} hostid'.format(target.busybox)).strip()
-    info.hostid = int(hostid_string, 16)
-    info.hostname = target.execute('{} hostname'.format(target.busybox)).strip()
 
     for i, name in enumerate(target.cpuinfo.cpu_names):
         cpu = CpuInfo()

--- a/wa/framework/version.py
+++ b/wa/framework/version.py
@@ -23,7 +23,7 @@ VersionTuple = namedtuple('Version', ['major', 'minor', 'revision', 'dev'])
 
 version = VersionTuple(3, 3, 1, 'dev1')
 
-required_devlib_version = VersionTuple(1, 3, 1, 'dev1')
+required_devlib_version = VersionTuple(1, 3, 1, 'dev2')
 
 
 def format_version(v):


### PR DESCRIPTION
Switch to using properties exposed by the target, allows for working around systems that cannot retrieve the hostname directly as per https://github.com/ARM-software/workload-automation/issues/1163 

Dependent on https://github.com/ARM-software/devlib/pull/538