### PR TITLE
docs: Update readthedocs package versions

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,3 +19,4 @@ python:
    install:
       - method: setuptools
         path: .
+      - requirements: doc/requirements.txt

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,6 @@
 nose
 numpy
 pandas
-sphinx_rtd_theme>=0.3.1
+sphinx_rtd_theme=1.0.0
+sphinx=4.2
+docutils<0.18


### PR DESCRIPTION
The latest sphinx and docutils versions currently used on readthedocs
are no longer compatible. Explicitly list the package versions that
should be used when building the documentation.