### PR TITLE
ci: Bump the python version used for running tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.5
+    - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
-        python-version: 3.5
+        python-version: 3.7
     - name: git-bash
       uses: pkg-src/github-action-git-bash@v1.1
     - name: Install dependencies
@@ -27,7 +27,7 @@ jobs:
         python -m pip install --upgrade pip
         cd /tmp && git clone https://github.com/ARM-software/devlib.git && cd devlib && pip install .
         cd $GITHUB_WORKSPACE && pip install .[test]
-        pip install pylint pep8 flake8 mock nose
+        python -m pip install pylint pep8 flake8 mock nose
     - name: Run pylint
       run: |
         cd $GITHUB_WORKSPACE && ./dev_scripts/pylint wa/
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
         python -m pip install --upgrade pip
         cd /tmp && git clone https://github.com/ARM-software/devlib.git && cd devlib && pip install .
         cd $GITHUB_WORKSPACE && pip install .[test]
-        python -m pip install pylint pep8 flake8 mock nose
+        python -m pip install pylint==2.6.2 pep8 flake8 mock nose
     - name: Run pylint
       run: |
         cd $GITHUB_WORKSPACE && ./dev_scripts/pylint wa/

--- a/dev_scripts/pylint
+++ b/dev_scripts/pylint
@@ -37,6 +37,9 @@ if [ "x$pylint_version" == "x" ]; then
 	pylint_version=$(python3 -c 'from pylint.__pkginfo__ import version; print(version)' 2>/dev/null)
 fi
 if [ "x$pylint_version" == "x" ]; then
+	pylint_version=$(python3 -c 'from pylint import version; print(version)' 2>/dev/null)
+fi
+if [ "x$pylint_version" == "x" ]; then
 	echo "ERROR: no pylint verison found; is it installed?"
 	exit 1
 fi


### PR DESCRIPTION
The latest devlib master branch requires Python >=3.7 therefore
bump the python version used to run the CI tests.