### PR TITLE
docs/.readthedocs: Bump the python version

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,7 +15,7 @@ formats: all
 
 # Set the version of Python and requirements required to build your docs
 python:
-   version: 3.7
+   version: 3.8
    install:
       - method: setuptools
         path: .


### PR DESCRIPTION
Bump the python version used to build the documentation
to prevent installation errors in the build environment.