### PR TITLE
add support for loading runtime-config as a plugin

### DIFF
--- a/wa/framework/target/runtime_parameter_manager.py
+++ b/wa/framework/target/runtime_parameter_manager.py
@@ -22,6 +22,7 @@ from wa.framework.target.runtime_config import (SysfileValuesRuntimeConfig,
                                                 CpuidleRuntimeConfig,
                                                 AndroidRuntimeConfig)
 from wa.utils.types import obj_dict, caseless_string
+from wa.framework import pluginloader
 
 
 class RuntimeParameterManager(object):
@@ -37,8 +38,15 @@ class RuntimeParameterManager(object):
 
     def __init__(self, target):
         self.target = target
-        self.runtime_configs = [cls(self.target) for cls in self.runtime_config_cls]
         self.runtime_params = {}
+
+        try:
+            for rt_cls in pluginloader.list_plugins(kind='runtime-config'):
+                if rt_cls not in self.runtime_config_cls:
+                    self.runtime_config_cls.append(rt_cls)
+        except ValueError:
+            pass
+        self.runtime_configs = [cls(self.target) for cls in self.runtime_config_cls]
 
         runtime_parameter = namedtuple('RuntimeParameter', 'cfg_point, rt_config')
         for cfg in self.runtime_configs:


### PR DESCRIPTION
This patch allows plugins to define their own runtime configurations. The primary motivation is to allow complex configurations that may be specific to a chip or device and have that configuration modifiable in sections to test sensitivity to those changes.