### PR TITLE
Mitigate CVE-2007-4995

### DIFF
--- a/wa/framework/output.py
+++ b/wa/framework/output.py
@@ -39,7 +39,8 @@ from wa.framework.run import RunState, RunInfo
 from wa.framework.target.info import TargetInfo
 from wa.framework.version import get_wa_version_with_commit
 from wa.utils.doc import format_simple_table
-from wa.utils.misc import touch, ensure_directory_exists, isiterable, format_ordered_dict
+from wa.utils.misc import (touch, ensure_directory_exists, isiterable,
+                           format_ordered_dict, safe_extract)
 from wa.utils.postgres import get_schema_versions
 from wa.utils.serializer import write_pod, read_pod, Podable, json
 from wa.utils.types import enum, numeric
@@ -854,7 +855,7 @@ class DatabaseOutput(Output):
     def _read_dir_artifact(self, artifact):
         artifact_path = tempfile.mkdtemp(prefix='wa_')
         with tarfile.open(fileobj=self.conn.lobject(int(artifact.path), mode='b'), mode='r|gz') as tar_file:
-            tar_file.extractall(artifact_path)
+            safe_extract(tar_file, artifact_path)
         self.conn.commit()
         return artifact_path
 

--- a/wa/instruments/misc.py
+++ b/wa/instruments/misc.py
@@ -37,7 +37,7 @@ from wa import Instrument, Parameter, very_fast
 from wa.framework.exception import ConfigError
 from wa.framework.instrument import slow
 from wa.utils.diff import diff_sysfs_dirs, diff_interrupt_files
-from wa.utils.misc import as_relative
+from wa.utils.misc import as_relative, safe_extract
 from wa.utils.misc import ensure_file_directory_exists as _f
 from wa.utils.misc import ensure_directory_exists as _d
 from wa.utils.types import list_of_strings
@@ -162,7 +162,7 @@ class SysfsExtractor(Instrument):
             self.target.execute('chmod 0777 {}'.format(on_device_tarball), as_root=True)
             self.target.pull(on_device_tarball, on_host_tarball)
             with tarfile.open(on_host_tarball, 'r:gz') as tf:
-                tf.extractall(context.output_directory)
+                safe_extract(tf, context.output_directory)
             self.target.remove(on_device_tarball)
             os.remove(on_host_tarball)
 

--- a/wa/utils/misc.py
+++ b/wa/utils/misc.py
@@ -56,7 +56,7 @@ from devlib.utils.misc import (ABI_MAP, check_output, walk_modules,
                                normalize, convert_new_lines, get_cpu_mask, unique,
                                isiterable, getch, as_relative, ranges_to_list, memoized,
                                list_to_ranges, list_to_mask, mask_to_list, which,
-                               to_identifier)
+                               to_identifier, safe_extract)
 
 check_output_logger = logging.getLogger('check_output')
 

--- a/wa/workloads/rt_app/__init__.py
+++ b/wa/workloads/rt_app/__init__.py
@@ -22,7 +22,7 @@ from subprocess import CalledProcessError
 
 from wa import Workload, Parameter, Executable, File
 from wa.framework.exception import WorkloadError, ResourceError, ConfigError
-from wa.utils.misc import check_output
+from wa.utils.misc import check_output, safe_extract
 from wa.utils.exec_control import once
 from wa.utils.types import cpu_mask
 
@@ -286,6 +286,6 @@ class RtApp(Workload):
         host_path = os.path.join(context.output_directory, TARBALL_FILENAME)
         self.target.pull(target_path, host_path)
         with tarfile.open(host_path, 'r:gz') as tf:
-            tf.extractall(context.output_directory)
+            safe_extract(tf, context.output_directory)
         os.remove(host_path)
         self.target.execute('rm -rf {}/*'.format(self.target_working_directory))

--- a/wa/workloads/speedometer/__init__.py
+++ b/wa/workloads/speedometer/__init__.py
@@ -27,6 +27,7 @@ import uuid
 from wa import Parameter, Workload, File
 from wa.framework.exception import WorkloadError
 from wa.utils.exec_control import once
+from wa.utils.misc import safe_extract
 
 from devlib.utils.android import adb_command
 
@@ -154,7 +155,7 @@ class Speedometer(Workload):
         # Host a copy of Speedometer locally
         tarball = context.get_resource(File(self, "speedometer_archive.tgz"))
         with tarfile.open(name=tarball) as handle:
-            handle.extractall(self.temp_dir.name)
+            safe_extract(handle, self.temp_dir.name)
         self.archive_server.start(self.document_root)
 
         Speedometer.speedometer_url = "http://localhost:{}/Speedometer2.0/index.html".format(


### PR DESCRIPTION
Prevent potential directory path traversal attacks (see https://www.trellix.com/en-us/about/newsroom/stories/research/tarfile-exploiting-the-world.html)

This is an alternative to the automatically generated https://github.com/ARM-software/workload-automation/pull/1196/ reusing the same fix added to devlib in https://github.com/ARM-software/devlib/pull/608.

Note: This cannot be merged until we can also bump the devlib dependency in WA to keep the versions aligned. 