### PR TITLE
framework/target: Add persistent_data_path to Android target descriptor

### DIFF
--- a/wa/framework/target/descriptor.py
+++ b/wa/framework/target/descriptor.py
@@ -541,6 +541,10 @@ TARGETS = {
                           description='''
                           Directory containing Android data
                           '''),
+                Parameter('persistent_data_path', kind=str, default='/storage/emulated/0/Android/data',
+                          description='''
+                          Directory containing persistent Android data
+                          '''),
                ], None),
     'chromeos': ((ChromeOsTarget, 'ChromeOsConnection', []), COMMON_TARGET_PARAMS +
                 [Parameter('package_data_directory', kind=str, default='/data/data',


### PR DESCRIPTION
Include persistent_data_path in the Android target descriptor within framework/target/descriptor.py in line with adding persistent_data_path to AndroidTarget in devlib. This commit relies on the relevant change being merged into devlib first.