### PR TITLE
fw/plugin: Try to load plugin paths as Python module name

### DIFF
--- a/wa/framework/plugin.py
+++ b/wa/framework/plugin.py
@@ -622,19 +622,26 @@ class PluginLoader(object):
             self.logger.debug('Checking path %s', path)
             if os.path.isfile(path):
                 self._discover_from_file(path)
-            for root, _, files in os.walk(path, followlinks=True):
-                should_skip = False
-                for igpath in ignore_paths:
-                    if root.startswith(igpath):
-                        should_skip = True
-                        break
-                if should_skip:
-                    continue
-                for fname in files:
-                    if os.path.splitext(fname)[1].lower() != '.py':
+            elif os.path.exists(path):
+                for root, _, files in os.walk(path, followlinks=True):
+                    should_skip = False
+                    for igpath in ignore_paths:
+                        if root.startswith(igpath):
+                            should_skip = True
+                            break
+                    if should_skip:
                         continue
-                    filepath = os.path.join(root, fname)
-                    self._discover_from_file(filepath)
+                    for fname in files:
+                        if os.path.splitext(fname)[1].lower() != '.py':
+                            continue
+                        filepath = os.path.join(root, fname)
+                        self._discover_from_file(filepath)
+            elif not os.path.isabs(path):
+                try:
+                    for module in walk_modules(path):
+                        self._discover_in_module(module)
+                except Exception: # NOQA pylint: disable=broad-except
+                    pass
 
     def _discover_from_file(self, filepath):
         try:


### PR DESCRIPTION
WA_PLUGIN_PATHS currently contains a list of filesystem paths to scan for plugins. This is appropriate for end-user plugins, but this is problematic for plugins distributed by a 3rd party, such as a plugin installed from PyPI.

In those cases, the path to the sources is unknown and typically depends on the specify Python version, local setup etc. What is constant is Python name of the package, e.g. "lisa.wa.plugins".

Extend the input allowed in WA_PLUGIN_PATHS by trying to load entries as a Python package name if:
    * There is no filesystem path with that name
    * The entry is a "relative path" (from an fs point of view)