### PR TITLE
workloads/speedometer: Add Bromite to package names

### DIFF
--- a/wa/workloads/speedometer/__init__.py
+++ b/wa/workloads/speedometer/__init__.py
@@ -89,7 +89,7 @@ class Speedometer(Workload):
     """
     supported_platforms = ["android"]
 
-    package_names = ["org.chromium.chrome", "com.android.chrome"]
+    package_names = ["org.chromium.chrome", "com.android.chrome", "org.bromite.chromium"]
     # This regex finds a single XML tag where property 1 and 2 are true:
     #  1. contains the attribute text="XXX" or content-desc="XXX"
     #  2. and exclusively either 2a or 2b is true:


### PR DESCRIPTION
Bromite is a fork of Chromium that's easily available for Android. Apart from small changes it works the same as Chromium and works with this speedometer workload. Add it to the 'package_names' list to allow using it as an option.

https://www.bromite.org/