### PR TITLE
docs: fix RTD build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,10 +13,16 @@ sphinx:
 # Build the docs in additional formats such as PDF and ePub
 formats: all
 
-# Set the version of Python and requirements required to build your docs
+
+# Configure the build environment
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Ensure doc dependencies are installed before building
 python:
-   version: 3.8
    install:
-      - method: setuptools
-        path: .
       - requirements: doc/requirements.txt
+      - method: pip
+        path: .

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,3 +4,4 @@ pandas
 sphinx_rtd_theme==1.0.0
 sphinx==4.2
 docutils<0.18
+devlib @ git+https://github.com/ARM-software/devlib@master

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018 ARM Limited
+# Copyright 2023 ARM Limited
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -68,7 +68,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'wa'
-copyright = u'2018, ARM Limited'
+copyright = u'2023, ARM Limited'
 author = u'ARM Limited'
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
- Bump python version used when building documentation.
- `setuptools` is a deprecated installation method on RTD so switch to `pip`.
- Add additional dependency on devlib master branch as RTD env is not respecting dependency_links during installation.
- Bump copyright year.