### PR TITLE
instruments/trace_cmd: Support setting trace-cmd mode

### DIFF
--- a/wa/instruments/trace_cmd.py
+++ b/wa/instruments/trace_cmd.py
@@ -158,6 +158,13 @@ class TraceCmdInstrument(Instrument):
                   description="""
                   The mode that trace-cmd will be started in.
                   For more details, consult the trace-cmd documentation.
+                  """),
+        Parameter('record_interval', kind=int, default=1000,
+                  description="""
+                  The interval for filesystem writes in record mode, in microseconds.
+                  The default is set to 1000 (1 ms).
+                  This is the time each recording process will sleep before waking up to
+                  record any new data that was written to the ring buffer.
                   """)
     ]
 
@@ -181,6 +188,7 @@ class TraceCmdInstrument(Instrument):
             strict=False,
             report_on_target=False,
             trace_cmd_mode=self.trace_cmd_mode,
+            record_interval=self.record_interval,
         )
         if self.report and self.report_on_target:
             collector_params['autoreport'] = True


### PR DESCRIPTION
The doc comment for the instrument mentions the option to select the trace_cmd_mode ('start' or 'record'). As far as I can tell this was never implemented. This commit adds the support for passing trace_cmd_mode to the FtraceCollector in devlib.

While at it, it also does some slight cleanup aronud the instrument, e.g. in the teardown() implementation which should be folded inside the collector instead of reimplemented here.