### PR TITLE
wa: Remove dependency on "imp" module and cleanup import mechanisms

### DIFF
--- a/dev_scripts/pylint_plugins.py
+++ b/dev_scripts/pylint_plugins.py
@@ -32,17 +32,11 @@ def transform(mod):
                 if b'pylint:' in text[0]:
                     msg = 'pylint directive found on the first line of {}; please move to below copyright header'
                     raise RuntimeError(msg.format(mod.name))
-                if sys.version_info[0] == 3:
-                    char = chr(text[0][0])
-                else:
-                    char = text[0][0]
+                char = chr(text[0][0])
                 if text[0].strip() and char != '#':
                     msg = 'first line of {} is not a comment; is the copyright header missing?'
                     raise RuntimeError(msg.format(mod.name))
-                if sys.version_info[0] == 3:
-                    text[0] = '# pylint: disable={}'.format(','.join(errors)).encode('utf-8')
-                else:
-                    text[0] = '# pylint: disable={}'.format(','.join(errors))
+                text[0] = '# pylint: disable={}'.format(','.join(errors)).encode('utf-8')
                 mod.file_bytes = b'\n'.join(text)
 
                 # This is what *should* happen, but doesn't work.

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ params = dict(
     license='Apache v2',
     maintainer='ARM Architecture & Technology Device Lab',
     maintainer_email='workload-automation@arm.com',
+    python_requires='>= 3.7',
     setup_requires=[
         'numpy<=1.16.4; python_version<"3"',
         'numpy; python_version>="3"',

--- a/wa/commands/revent.py
+++ b/wa/commands/revent.py
@@ -25,10 +25,6 @@ from wa.framework.target.manager import TargetManager
 from wa.utils.revent import ReventRecorder
 
 
-if sys.version_info[0] == 3:
-    raw_input = input  # pylint: disable=redefined-builtin
-
-
 class RecordCommand(Command):
 
     name = 'record'
@@ -137,11 +133,11 @@ class RecordCommand(Command):
     def record(self, revent_file, name, output_path):
         msg = 'Press Enter when you are ready to record {}...'
         self.logger.info(msg.format(name))
-        raw_input('')
+        input('')
         self.revent_recorder.start_record(revent_file)
         msg = 'Press Enter when you have finished recording {}...'
         self.logger.info(msg.format(name))
-        raw_input('')
+        input('')
         self.revent_recorder.stop_record()
 
         if not os.path.isdir(output_path):

--- a/wa/commands/show.py
+++ b/wa/commands/show.py
@@ -73,11 +73,8 @@ class ShowCommand(Command):
 
         if which('pandoc'):
             p = Popen(['pandoc', '-f', 'rst', '-t', 'man'], stdin=PIPE, stdout=PIPE, stderr=PIPE)
-            if sys.version_info[0] == 3:
-                output, _ = p.communicate(rst_output.encode(sys.stdin.encoding))
-                output = output.decode(sys.stdout.encoding)
-            else:
-                output, _ = p.communicate(rst_output)
+            output, _ = p.communicate(rst_output.encode(sys.stdin.encoding))
+            output = output.decode(sys.stdout.encoding)
 
             # Make sure to double escape back slashes
             output = output.replace('\\', '\\\\\\')

--- a/wa/framework/getters.py
+++ b/wa/framework/getters.py
@@ -244,10 +244,7 @@ class Http(ResourceGetter):
                                              response.status_code,
                                              response.reason))
             return {}
-        if sys.version_info[0] == 3:
-            content = response.content.decode('utf-8')
-        else:
-            content = response.content
+        content = response.content.decode('utf-8')
         return json.loads(content)
 
     def download_asset(self, asset, owner_name):

--- a/wa/framework/instrument.py
+++ b/wa/framework/instrument.py
@@ -325,10 +325,7 @@ def install(instrument, context):
         if not callable(attr):
             msg = 'Attribute {} not callable in {}.'
             raise ValueError(msg.format(attr_name, instrument))
-        if sys.version_info[0] == 3:
-            argspec = inspect.getfullargspec(attr)
-        else:
-            argspec = inspect.getargspec(attr)  # pylint: disable=deprecated-method
+        argspec = inspect.getfullargspec(attr)
         arg_num = len(argspec.args)
         # Instrument callbacks will be passed exactly two arguments: self
         # (the instrument instance to which the callback is bound) and

--- a/wa/framework/instrument.py
+++ b/wa/framework/instrument.py
@@ -98,7 +98,6 @@ and the code to clear these file goes in teardown method. ::
 
 """
 
-import sys
 import logging
 import inspect
 from collections import OrderedDict

--- a/wa/framework/plugin.py
+++ b/wa/framework/plugin.py
@@ -18,8 +18,6 @@
 import os
 import sys
 import inspect
-import imp
-import string
 import logging
 from collections import OrderedDict, defaultdict
 from itertools import chain
@@ -32,14 +30,8 @@ from wa.framework.exception import (NotFoundError, PluginLoaderError, TargetErro
                                     ValidationError, ConfigError, HostError)
 from wa.utils import log
 from wa.utils.misc import (ensure_directory_exists as _d, walk_modules, load_class,
-                           merge_dicts_simple, get_article)
+                           merge_dicts_simple, get_article, import_path)
 from wa.utils.types import identifier
-
-
-if sys.version_info[0] == 3:
-    MODNAME_TRANS = str.maketrans(':/\\.', '____')
-else:
-    MODNAME_TRANS = string.maketrans(':/\\.', '____')
 
 
 class AttributeCollection(object):
@@ -645,8 +637,7 @@ class PluginLoader(object):
 
     def _discover_from_file(self, filepath):
         try:
-            modname = os.path.splitext(filepath[1:])[0].translate(MODNAME_TRANS)
-            module = imp.load_source(modname, filepath)
+            module = import_path(filepath)
             self._discover_in_module(module)
         except (SystemExit, ImportError) as e:
             if self.keep_going:

--- a/wa/framework/version.py
+++ b/wa/framework/version.py
@@ -57,7 +57,4 @@ def get_commit():
     p.wait()
     if p.returncode:
         return None
-    if sys.version_info[0] == 3 and isinstance(std, bytes):
-        return std[:8].decode(sys.stdout.encoding or 'utf-8')
-    else:
-        return std[:8]
+    return std[:8].decode(sys.stdout.encoding or 'utf-8')

--- a/wa/utils/misc.py
+++ b/wa/utils/misc.py
@@ -289,7 +289,7 @@ def get_article(word):
               in all case; e.g. this will return ``"a hour"``.
 
     """
-    return'an' if word[0] in 'aoeiu' else 'a'
+    return 'an' if word[0] in 'aoeiu' else 'a'
 
 
 def get_random_string(length):

--- a/wa/utils/misc.py
+++ b/wa/utils/misc.py
@@ -21,10 +21,12 @@ Miscellaneous functions that don't fit anywhere else.
 
 import errno
 import hashlib
-import imp
+import importlib
+import inspect
 import logging
 import math
 import os
+import pathlib
 import random
 import re
 import shutil
@@ -308,32 +310,57 @@ class LoadSyntaxError(Exception):
 RAND_MOD_NAME_LEN = 30
 
 
-def load_struct_from_python(filepath=None, text=None):
+def import_path(filepath, module_name=None):
+    """
+    Programmatically import the given Python source file under the name
+    ``module_name``. If ``module_name`` is not provided, a stable name based on
+    ``filepath`` will be created. Note that this module name cannot be relied
+    on, so don't make write import statements assuming this will be stable in
+    the future.
+    """
+    if not module_name:
+        path = pathlib.Path(filepath).resolve()
+        id_ = to_identifier(str(path))
+        module_name = f'wa._user_import.{id_}'
+
+    try:
+        return sys.modules[module_name]
+    except KeyError:
+        spec = importlib.util.spec_from_file_location(module_name, filepath)
+        module = importlib.util.module_from_spec(spec)
+        try:
+            sys.modules[module_name] = module
+            spec.loader.exec_module(module)
+        except BaseException:
+            sys.modules.pop(module_name, None)
+            raise
+        else:
+            # We could return the "module" object, but that would not take into
+            # account any manipulation the module did on sys.modules when
+            # executing. To be consistent with the import statement, re-lookup
+            # the module name.
+            return sys.modules[module_name]
+
+
+def load_struct_from_python(filepath):
     """Parses a config structure from a .py file. The structure should be composed
     of basic Python types (strings, ints, lists, dicts, etc.)."""
-    if not (filepath or text) or (filepath and text):
-        raise ValueError('Exactly one of filepath or text must be specified.')
+
     try:
-        if filepath:
-            modname = to_identifier(filepath)
-            mod = imp.load_source(modname, filepath)
-        else:
-            modname = get_random_string(RAND_MOD_NAME_LEN)
-            while modname in sys.modules:  # highly unlikely, but...
-                modname = get_random_string(RAND_MOD_NAME_LEN)
-            mod = imp.new_module(modname)
-            exec(text, mod.__dict__)  # pylint: disable=exec-used
-        return dict((k, v)
-                    for k, v in mod.__dict__.items()
-                    if not k.startswith('_'))
+        mod = import_path(filepath)
     except SyntaxError as e:
         raise LoadSyntaxError(e.message, filepath, e.lineno)
+    else:
+        return {
+            k: v
+            for k, v in inspect.getmembers(mod)
+            if not k.startswith('_')
+        }
 
 
 def load_struct_from_yaml(filepath=None, text=None):
     """Parses a config structure from a .yaml file. The structure should be composed
     of basic Python types (strings, ints, lists, dicts, etc.)."""
-
     # Import here to avoid circular imports
     # pylint: disable=wrong-import-position,cyclic-import, import-outside-toplevel
     from wa.utils.serializer import yaml

--- a/wa/utils/misc.py
+++ b/wa/utils/misc.py
@@ -236,7 +236,12 @@ def load_class(classpath):
     """Loads the specified Python class. ``classpath`` must be a fully-qualified
     class name (i.e. namspaced under module/package)."""
     modname, clsname = classpath.rsplit('.', 1)
-    return getattr(__import__(modname), clsname)
+    mod = importlib.import_module(modname)
+    cls = getattr(mod, clsname)
+    if isinstance(cls, type):
+        return cls
+    else:
+        raise ValueError(f'The classpath "{classpath}" does not point at a class: {cls}')
 
 
 def get_pager():

--- a/wa/utils/misc.py
+++ b/wa/utils/misc.py
@@ -41,10 +41,7 @@ from functools import reduce  # pylint: disable=redefined-builtin
 from operator import mul
 from tempfile import gettempdir, NamedTemporaryFile
 from time import sleep
-if sys.version_info[0] == 3:
-    from io import StringIO
-else:
-    from io import BytesIO as StringIO
+from io import StringIO
 # pylint: disable=wrong-import-position,unused-import
 from itertools import chain, cycle
 from distutils.spawn import find_executable  # pylint: disable=no-name-in-module, import-error

--- a/wa/utils/types.py
+++ b/wa/utils/types.py
@@ -29,15 +29,14 @@ import os
 import re
 import numbers
 import shlex
-import sys
 from bisect import insort
 from urllib.parse import quote, unquote  # pylint: disable=no-name-in-module, import-error
-from past.builtins import basestring  # pylint: disable=redefined-builtin
 # pylint: disable=wrong-import-position
 from collections import defaultdict
 from collections.abc import MutableMapping
 from functools import total_ordering
 
+from past.builtins import basestring  # pylint: disable=redefined-builtin
 from future.utils import with_metaclass
 
 from devlib.utils.types import identifier, boolean, integer, numeric, caseless_string

--- a/wa/utils/types.py
+++ b/wa/utils/types.py
@@ -31,12 +31,8 @@ import numbers
 import shlex
 import sys
 from bisect import insort
-if sys.version_info[0] == 3:
-    from urllib.parse import quote, unquote  # pylint: disable=no-name-in-module, import-error
-    from past.builtins import basestring  # pylint: disable=redefined-builtin
-    long = int  # pylint: disable=redefined-builtin
-else:
-    from urllib import quote, unquote  # pylint: disable=no-name-in-module
+from urllib.parse import quote, unquote  # pylint: disable=no-name-in-module, import-error
+from past.builtins import basestring  # pylint: disable=redefined-builtin
 # pylint: disable=wrong-import-position
 from collections import defaultdict
 from collections.abc import MutableMapping
@@ -710,8 +706,6 @@ class ParameterDict(dict):
             prefix = 'f'
         elif isinstance(obj, bool):
             prefix = 'b'
-        elif isinstance(obj, long):
-            prefix = 'i'
         elif isinstance(obj, int):
             prefix = 'i'
         elif obj is None:
@@ -792,10 +786,7 @@ class ParameterDict(dict):
         return (key, self._decode(value))
 
     def iter_encoded_items(self):
-        if sys.version_info[0] == 3:
-            return dict.items(self)
-        else:
-            return dict.iteritems(self)
+        return dict.items(self)
 
     def get_encoded_value(self, name):
         return dict.__getitem__(self, name)

--- a/wa/workloads/jankbench/__init__.py
+++ b/wa/workloads/jankbench/__init__.py
@@ -223,8 +223,7 @@ class JankbenchRunMonitor(threading.Thread):
                 ready, _, _ = select.select([proc.stdout, proc.stderr], [], [], 2)
                 if ready:
                     line = ready[0].readline()
-                    if sys.version_info[0] == 3:
-                        line = line.decode(sys.stdout.encoding, 'replace')
+                    line = line.decode(sys.stdout.encoding, 'replace')
                     if self.regex.search(line):
                         self.run_ended.set()
         proc.terminate()

--- a/wa/workloads/meabo/__init__.py
+++ b/wa/workloads/meabo/__init__.py
@@ -256,10 +256,7 @@ class Meabo(Workload):
 
         outfile = os.path.join(context.output_directory, 'meabo-output.txt')
         with open(outfile, 'wb') as wfh:
-            if sys.version_info[0] == 3:
-                wfh.write(self.output.encode('utf-8'))
-            else:
-                wfh.write(self.output)
+            wfh.write(self.output.encode('utf-8'))
         context.add_artifact('meabo-output', outfile, kind='raw')
 
         cur_phase = 0

--- a/wa/workloads/pcmark/__init__.py
+++ b/wa/workloads/pcmark/__init__.py
@@ -89,8 +89,7 @@ class PcMark(ApkUiautoWorkload):
     def update_output(self, context):
         expected_results = len(self.regex_matches[self.major_version])
         zf = zipfile.ZipFile(os.path.join(context.output_directory, self.result_file), 'r').read('Result.xml')
-        if sys.version_info[0] == 3:
-            zf = zf.decode(sys.stdout.encoding)
+        zf = zf.decode(sys.stdout.encoding)
         for line in zf.split('\n'):
             for regex in self.regex_matches[self.major_version]:
                 match = regex.search(line)


### PR DESCRIPTION
Python 3.12 removed the "imp" module, so use importlib instead.
Also fix `load_class()` so that it works if the class is in a submodule.

Note that this PR was somewhat unit-tested (the new functions have been tested) but the integration in the rest of WA has not.