### PR TITLE
UIBenchJankTests: modification to support Android 14 version

### DIFF
--- a/wa/framework/workload.py
+++ b/wa/framework/workload.py
@@ -945,7 +945,7 @@ class TestPackageHandler(PackageHandler):
     def setup(self, context):
         self.initialize_package(context)
 
-        words = ['am', 'instrument']
+        words = ['am', 'instrument', '--user', '0']
         if self.raw:
             words.append('-r')
         if self.wait:


### PR DESCRIPTION
"--user <USER_ID>" (current user: 0) option is added to activity manager (am) command because of "Invalid userId" error. Tested with other benchmarks (geekbench) as well.