### PR TITLE
fw/rt_config: Add unlock_screen config option in runtime_parameters

### DIFF
--- a/doc/source/user_information/user_reference/runtime_parameters.rst
+++ b/doc/source/user_information/user_reference/runtime_parameters.rst
@@ -33,6 +33,7 @@ states.
                   iterations: 1
                   runtime_parameters:
                         screen_on: false
+                        unlock_screen: 'vertical'
                 - name: benchmarkpi
                   iterations: 1
         sections:
@@ -207,6 +208,13 @@ Android Specific Runtime Parameters
 
 :screen_on: A ``boolean`` to specify whether the devices screen should be
     turned on. Defaults to ``True``.
+
+:unlock_screen: A ``String`` to specify how the devices screen should be
+    unlocked. Unlocking screen is disabled by default. ``vertical``, ``diagonal``
+    and ``horizontal`` are the supported values (see :meth:`devlib.AndroidTarget.swipe_to_unlock`).
+    Note that unlocking succeeds when no passcode is set. Since unlocking screen
+    requires turning on the screen, this option overrides value of ``screen_on``
+    option.
 
 .. _setting-sysfiles:
 


### PR DESCRIPTION
Introduce 'unlock_screen' option in order to help in automating Android tests by unlocking device screen automatically. Surely this works only if no passcode is set.

User can tell how to unlock screen (e.g., diagonal, vertical, ...) via 'unlock_screen' option. If unlocking the screen is undesired, then 'unlock_screen' should be set to empty string (e.g., '').

'unlock_screen' option is effective if 'screen_on' option is set to true. Its default value is 'vertical'. Since 'screen_on' is also true by default, the screen will be unlocked via 'vertical' direction in default settings.

Note that this patch depends on
https://github.com/ARM-software/devlib/pull/659 in devlib repo.