### PR TITLE
target/descriptor: Support adb_port parameter

### DIFF
--- a/doc/source/user_information/user_guide.rst
+++ b/doc/source/user_information/user_guide.rst
@@ -373,6 +373,7 @@ below:
             device: generic_android
             device_config:
                 adb_server: null
+                adb_port: null
                 big_core: null
                 core_clusters: null
                 core_names: null

--- a/wa/framework/target/descriptor.py
+++ b/wa/framework/target/descriptor.py
@@ -309,6 +309,11 @@ CONNECTION_PARAMS = {
             ADB server to connect to.
             """),
         Parameter(
+            'adb_port', kind=int,
+            description="""
+            ADB port to connect to.
+            """),
+        Parameter(
             'poll_transfers', kind=bool,
             default=True,
             description="""


### PR DESCRIPTION
devlib/AdbConnection class supports customizing ADB port number. Enable that feature in WA side.