### PR TITLE
instruments/trace_cmd: Add tracing mode support to TraceCmdInstrument()

### DIFF
--- a/doc/source/user_information/user_guide.rst
+++ b/doc/source/user_information/user_guide.rst
@@ -400,6 +400,7 @@ below:
                 no_install: false
                 report: true
                 report_on_target: false
+                mode: write-to-memory
             csv:
                 extra_columns: null
                 use_all_classifiers: false

--- a/doc/source/user_information/user_reference/agenda.rst
+++ b/doc/source/user_information/user_reference/agenda.rst
@@ -45,6 +45,7 @@ An example agenda can be seen here:
             no_install: false
             report: true
             report_on_target: false
+            mode: write-to-disk
         csv:                    # Provide config for the csv augmentation
             use_all_classifiers: true
 

--- a/wa/instruments/trace_cmd.py
+++ b/wa/instruments/trace_cmd.py
@@ -162,6 +162,13 @@ class TraceCmdInstrument(Instrument):
                             installed on the host (the one in your
                             distribution's repos may be too old).
                   """),
+        Parameter('mode', kind=str, default='write-to-memory',
+                  allowed_values=['write-to-disk', 'write-to-memory'],
+                  description="""
+                  Specifies whether collected traces should be saved in memory or disk.
+                  Extensive workloads may hit out of memory issue. Hence, write-to-disk
+                  mode can help in such cases.
+                  """),
     ]
 
     def __init__(self, target, **kwargs):
@@ -183,6 +190,7 @@ class TraceCmdInstrument(Instrument):
             no_install=self.no_install,
             strict=False,
             report_on_target=False,
+            mode=self.mode,
         )
         if self.report and self.report_on_target:
             collector_params['autoreport'] = True
@@ -215,12 +223,14 @@ class TraceCmdInstrument(Instrument):
         if not self.collector:
             return
         self.logger.info('Extracting trace from target...')
-        outfile = os.path.join(context.output_directory, 'trace.dat')
+        outfile = os.path.join(context.output_directory, OUTPUT_TRACE_FILE)
+
         self.collector.set_output(outfile)
         self.collector.get_data()
         context.add_artifact('trace-cmd-bin', outfile, 'data')
         if self.report:
-            textfile = os.path.join(context.output_directory, 'trace.txt')
+            textfile = os.path.join(context.output_directory, OUTPUT_TEXT_FILE)
+
             if not self.report_on_target:
                 self.collector.report(outfile, textfile)
             context.add_artifact('trace-cmd-txt', textfile, 'export')


### PR DESCRIPTION
Implement tracing mode support (mainly for write-to-disk mode) in TraceCmdInstrument, enabling efficient collection of large trace datasets without encountering memory limitations.

This feature is particularly useful for scenarios requiring extensive trace data.

Additional changes:
- Replace hardcoded strings with corresponding string literals for improved maintainability.