### PR TITLE
workloads/speedometer: Fix SyntaxWarning exceptions in regex pattern

### DIFF
--- a/wa/workloads/speedometer/__init__.py
+++ b/wa/workloads/speedometer/__init__.py
@@ -105,9 +105,9 @@ class Speedometer(Workload):
     #  _only_ in the case we didn't see it before.
     #  Since 'index="3"' is always on the left side of the value.
     regex = re.compile(
-        '<[^>]*(?P<Z>index="3"|resource-id="result-number")?[^>]*'
-        '(?:text|content-desc)="(?P<value>\d+.\d+)"[^>]*'
-        '(?(Z)|resource-id="result-number")[^>]*\/>'
+        r'<[^>]*(?P<Z>index="3"|resource-id="result-number")?[^>]*'
+        r'(?:text|content-desc)="(?P<value>\d+.\d+)"[^>]*'
+        r'(?(Z)|resource-id="result-number")[^>]*\/>'
     )
 
     parameters = [


### PR DESCRIPTION
The regex pattern for extracting speedometer score causes these exceptions due to unescaped `\d` and `\/` sequences:

```
wa/workloads/speedometer/__init__.py:109: SyntaxWarning: invalid escape sequence '\d'
  '(?:text|content-desc)="(?P<value>\d+.\d+)"[^>]*'
wa/workloads/speedometer/__init__.py:110: SyntaxWarning: invalid escape sequence '\/'
  '(?(Z)|resource-id="result-number")[^>]*\/>'
```

Fix the problem via defining the regex pattern as raw string literal to properly escape backslashes.