### PR TITLE
ci: Bump python versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,13 +13,13 @@ on:
 
 jobs:
   Run-Linters-and-Tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8.18
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8.18
     - name: git-bash
       uses: pkg-src/github-action-git-bash@v1.1
     - name: Install dependencies
@@ -39,10 +39,10 @@ jobs:
         nosetests
 
   Execute-Test-Workload-and-Process:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7.17, 3.8.18, 3.9.21, 3.10.16, 3.13.2]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -64,10 +64,10 @@ jobs:
         cd /tmp && wa process -f -p csv idle_workload
 
   Test-WA-Commands:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7.17, 3.8.18, 3.9.21, 3.10.16, 3.13.2]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/wa/commands/create.py
+++ b/wa/commands/create.py
@@ -23,7 +23,6 @@ import re
 import uuid
 import getpass
 from collections import OrderedDict
-from distutils.dir_util import copy_tree  # pylint: disable=no-name-in-module, import-error
 
 from devlib.utils.types import identifier
 try:
@@ -42,6 +41,24 @@ from wa.utils.misc import (ensure_directory_exists as _d, capitalize,
                            ensure_file_directory_exists as _f)
 from wa.utils.postgres import get_schema, POSTGRES_SCHEMA_DIR
 from wa.utils.serializer import yaml
+
+if sys.version_info >= (3, 8):
+    def copy_tree(src, dst):
+        from shutil import copy, copytree  # pylint: disable=import-outside-toplevel
+        copytree(
+            src,
+            dst,
+            # dirs_exist_ok=True only exists in Python >= 3.8
+            dirs_exist_ok=True,
+            # Align with devlib and only copy the content without metadata
+            copy_function=copy
+        )
+else:
+    def copy_tree(src, dst):
+        # pylint: disable=import-outside-toplevel, redefined-outer-name
+        from distutils.dir_util import copy_tree
+        # Align with devlib and only copy the content without metadata
+        copy_tree(src, dst, preserve_mode=False, preserve_times=False)
 
 
 TEMPLATES_DIR = os.path.join(os.path.dirname(__file__), 'templates')

--- a/wa/utils/misc.py
+++ b/wa/utils/misc.py
@@ -44,7 +44,11 @@ from time import sleep
 from io import StringIO
 # pylint: disable=wrong-import-position,unused-import
 from itertools import chain, cycle
-from distutils.spawn import find_executable  # pylint: disable=no-name-in-module, import-error
+
+try:
+    from shutil import which as find_executable
+except ImportError:
+    from distutils.spawn import find_executable  # pylint: disable=no-name-in-module, import-error
 
 from dateutil import tz
 


### PR DESCRIPTION
Update CI to run with later python versions and update to align with latest available versions provided by github actions.