### PR TITLE
Add support for Honor of Kings game

### DIFF
--- a/wa/framework/workload.py
+++ b/wa/framework/workload.py
@@ -584,6 +584,7 @@ class ReventGUI(object):
 
     def __init__(self, workload, target, setup_timeout, run_timeout,
                  extract_results_timeout, teardown_timeout):
+        self.logger = logging.getLogger(self.__class__.__name__)
         self.workload = workload
         self.target = target
         self.setup_timeout = setup_timeout
@@ -596,7 +597,6 @@ class ReventGUI(object):
         self.on_target_run_revent = self.target.get_workpath('{}.run.revent'.format(self.target.model))
         self.on_target_extract_results_revent = self.target.get_workpath('{}.extract_results.revent'.format(self.target.model))
         self.on_target_teardown_revent = self.target.get_workpath('{}.teardown.revent'.format(self.target.model))
-        self.logger = logging.getLogger('revent')
         self.revent_setup_file = None
         self.revent_run_file = None
         self.revent_extract_results_file = None
@@ -629,8 +629,9 @@ class ReventGUI(object):
                                         timeout=self.setup_timeout)
 
     def run(self):
-        msg = 'Replaying {}'
-        self.logger.debug(msg.format(os.path.basename(self.on_target_run_revent)))
+        self.logger.debug('Replaying "%s" with %d seconds timeout',
+                          os.path.basename(self.on_target_run_revent),
+                          self.run_timeout)
         self.revent_recorder.replay(self.on_target_run_revent,
                                     timeout=self.run_timeout)
         self.logger.debug('Replay completed.')

--- a/wa/workloads/honorofkings/__init__.py
+++ b/wa/workloads/honorofkings/__init__.py
@@ -1,0 +1,61 @@
+#    Copyright 2025 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+
+from wa import ApkReventWorkload, Parameter
+
+
+class HoK(ApkReventWorkload):
+    name = 'honorofkings'
+    uninstall = False
+    clear_data_on_reset = False  # Don't clear assets on exit
+    requires_network = True  # The game requires network connection
+    description = (
+        'Launch a match replay in Honor of Kings.\n\n'
+        'The game must already have a user logged in and the plugins downloaded.'
+    )
+    package_names = [
+        'com.levelinfinite.sgameGlobal',
+        'com.tencent.tmgp.sgame',
+    ]
+
+    parameters = [
+        Parameter(
+            'activity',
+            kind=str,
+            default='.SGameGlobalActivity',
+            description='Activity name of Honor of Kings game.',
+        ),
+        Parameter(
+            'replay_file',
+            kind=str,
+            default='replay.abc',
+            description='Honor of Kings Replay file name.',
+        ),
+    ]
+
+    def setup(self, context):
+        upload_dir = self.target.path.join(
+            self.target.external_storage_app_dir,
+            self.apk.apk_info.package,
+            'files',
+            'Replay'
+        )
+        replay_file = os.path.join(self.dependencies_directory, self.replay_file)
+        self.logger.debug('Uploading "%s" to "%s"...', replay_file, upload_dir)
+        self.target.push(replay_file, upload_dir)
+
+        super().setup(context)


### PR DESCRIPTION
- **framework: utils: Improve logging in revent replay related methods:**

  Also fix typos around the modified lines.

- **workloads: Add support for Honor of Kings game:**

    Introduce a new workload for automating match replays in Honor of Kings.
    This workload leverages ApkReventWorkload to launch the game and play
    back a specified replay file.

    Allow customization through parameters:
    - `activity`: Specifies the activity string of the game.
    - `replay_file`: Designates the replay file to be uploaded.

    The game can be replayed via `wa replay` command as well, but this
    plugin makes data collection (`fps`, `trace-cmd` like augmentations)
    a lot easier.
