### PR TITLE
framework: Re-enable instruments before finalizing run

### DIFF
--- a/wa/framework/execution.py
+++ b/wa/framework/execution.py
@@ -532,6 +532,7 @@ class Runner(object):
                 job.finalize(self.context)
         self.logger.info('Finalizing run')
         self.context.end_run()
+        instrumentation.enable_all()
         self.pm.enable_all()
         with signal.wrap('RUN_OUTPUT_PROCESSED', self):
             self.pm.process_run_output(self.context)


### PR DESCRIPTION
Ensure all instruments are re-enabled prior to run finalization so their `finalize()` methods are invoked. This fixes an issue where instruments not enabled during the last job skipped finalization.

Fixes: #1295